### PR TITLE
[WebKit] json rpc interface compatible

### DIFF
--- a/WebKitBrowser/WebKitBrowser.cpp
+++ b/WebKitBrowser/WebKitBrowser.cpp
@@ -32,6 +32,7 @@ namespace Plugin {
         ASSERT(_service == nullptr);
         ASSERT(_browser == nullptr);
         ASSERT(_memory == nullptr);
+        ASSERT(_application == nullptr);
 
         _connectionId = 0;
         _service = service;
@@ -54,29 +55,37 @@ namespace Plugin {
                 _browser->Release();
                 _browser = nullptr;
 
-                stateControl->Release();
-
             } else {
-                _browser->Register(&_notification);
+                _application = _browser->QueryInterface<Exchange::IApplication>();
+                if (_application != nullptr) {
+                    _browser->Register(&_notification);
 
-                const RPC::IRemoteConnection *connection = _service->RemoteConnection(_connectionId);
-                _memory = WPEFramework::WebKitBrowser::MemoryObserver(connection);
-                ASSERT(_memory != nullptr);
-                if (connection != nullptr)
-                    connection->Release();
+                    const RPC::IRemoteConnection *connection = _service->RemoteConnection(_connectionId);
+                    _memory = WPEFramework::WebKitBrowser::MemoryObserver(connection);
+                    ASSERT(_memory != nullptr);
+                    if (connection != nullptr) {
+                        connection->Release();
+                    }
 
-                if (stateControl->Configure(_service) != Core::ERROR_NONE) {
-                  if (_memory != nullptr) {
-                    _memory->Release();
-                    _memory = nullptr;
-                  }
-                  _browser->Unregister(&_notification);
-                  _browser->Release();
-                  _browser = nullptr;
+                    if (stateControl->Configure(_service) != Core::ERROR_NONE) {
+                        if (_memory != nullptr) {
+                            _memory->Release();
+                            _memory = nullptr;
+                        }
+                        _application->Release();
+                        _application = nullptr;
+                        _browser->Unregister(&_notification);
+                        _browser->Release();
+                        _browser = nullptr;
+                    } else {
+                        stateControl->Register(&_notification);
+                    }
+                    stateControl->Release();
                 } else {
-                  stateControl->Register(&_notification);
+                    stateControl->Release();
+                    _browser->Release();
+                    _browser = nullptr;
                 }
-                stateControl->Release();
             }
         }
 
@@ -96,6 +105,7 @@ namespace Plugin {
     {
         ASSERT(_service == service);
         ASSERT(_browser != nullptr);
+        ASSERT(_application != nullptr);
         ASSERT(_memory != nullptr);
 
         if (_browser == nullptr)
@@ -105,6 +115,7 @@ namespace Plugin {
         _service->Unregister(&_notification);
         _browser->Unregister(&_notification);
         _memory->Release();
+        _application->Release();
         Exchange::JWebBrowser::Unregister(*this);
         UnregisterAll();
 
@@ -133,6 +144,7 @@ namespace Plugin {
 
         _service = nullptr;
         _browser = nullptr;
+        _application = nullptr;
         _memory = nullptr;
     }
 
@@ -167,10 +179,11 @@ namespace Plugin {
             PluginHost::IStateControl* stateControl(_browser->QueryInterface<PluginHost::IStateControl>());
 
             ASSERT(stateControl != nullptr);
+            ASSERT(_application != nullptr);
 
             if (request.Verb == Web::Request::HTTP_GET) {
                 bool visible = false;
-                static_cast<const WPEFramework::Exchange::IWebBrowser*>(_browser)->Visible(visible);
+                static_cast<const WPEFramework::Exchange::IApplication*>(_application)->Visible(visible);
                 PluginHost::IStateControl::state currentState = stateControl->State();
                 Core::ProxyType<Web::JSONBodyType<WebKitBrowser::Data>> body(_jsonBodyDataFactory.Element());
                 string url;
@@ -194,9 +207,9 @@ namespace Plugin {
                 } else if (index.Remainder() == _T("Resume")) {
                     stateControl->Request(PluginHost::IStateControl::RESUME);
                 } else if (index.Remainder() == _T("Hide")) {
-                    _browser->Visible(Exchange::IWebBrowser::Visibility::HIDDEN);
+                    _browser->Visibility(Exchange::IWebBrowser::VisibilityType::HIDDEN);
                 } else if (index.Remainder() == _T("Show")) {
-                    _browser->Visible(Exchange::IWebBrowser::Visibility::VISIBLE);
+                    _browser->Visibility(Exchange::IWebBrowser::VisibilityType::VISIBLE);
                 } else if ((index.Remainder() == _T("URL")) && (request.HasBody() == true) && (request.Body<const Data>()->URL.Value().empty() == false)) {
                     const string url = request.Body<const Data>()->URL.Value();
                     _browser->URL(url);
@@ -272,10 +285,11 @@ namespace Plugin {
         Exchange::JWebBrowser::Event::PageClosure(*this);
     }
 
-    void WebKitBrowser::BridgeQuery(const string& message)
+    void WebKitBrowser::BridgeQueryResponse(const string& message)
     {
-        TRACE(Trace::Information, (_T("BridgeQuery: %s"), message.c_str()));
-        Exchange::JWebBrowser::Event::BridgeQuery(*this, message);
+        TRACE(Trace::Information, (_T("BridgeQueryResponse: %s"), message.c_str()));
+        Exchange::JWebBrowser::Event::BridgeQueryResponse(*this, message);
+        event_bridgequery(message);
     }
 
     void WebKitBrowser::StateChange(const PluginHost::IStateControl::state state)

--- a/WebKitBrowser/WebKitBrowser.h
+++ b/WebKitBrowser/WebKitBrowser.h
@@ -22,9 +22,11 @@
 
 #include "Module.h"
 #include <interfaces/IBrowser.h>
-
+#include <interfaces/IApplication.h>
 #include <interfaces/IMemory.h>
+
 #include <interfaces/json/JsonData_Browser.h>
+#include <interfaces/json/JsonData_WebKitBrowser.h>
 #include <interfaces/json/JsonData_StateControl.h>
 #include <interfaces/json/JWebBrowser.h>
 
@@ -81,9 +83,9 @@ namespace Plugin {
             {
                 _parent.PageClosure();
             }
-            void BridgeQuery(const string& message) override
+            void BridgeQueryResponse(const string& message) override
             {
-                _parent.BridgeQuery(message);
+                _parent.BridgeQueryResponse(message);
             }
             void StateChange(const PluginHost::IStateControl::state state) override
             {
@@ -174,6 +176,7 @@ namespace Plugin {
         INTERFACE_ENTRY(PluginHost::IDispatcher)
         INTERFACE_AGGREGATE(PluginHost::IStateControl, _browser)
         INTERFACE_AGGREGATE(Exchange::IBrowser, _browser)
+        INTERFACE_AGGREGATE(Exchange::IApplication, _application)
         INTERFACE_AGGREGATE(Exchange::IWebBrowser, _browser)
         INTERFACE_AGGREGATE(Exchange::IMemory, _memory)
         END_INTERFACE_MAP
@@ -212,7 +215,7 @@ namespace Plugin {
         void URLChange(const string& URL, bool loaded);
         void VisibilityChange(const bool hidden);
         void PageClosure();
-        void BridgeQuery(const string& message);
+        void BridgeQueryResponse(const string& message);
         void StateChange(const PluginHost::IStateControl::state state);
         uint32_t DeleteDir(const string& path);
 
@@ -222,6 +225,11 @@ namespace Plugin {
         uint32_t get_state(Core::JSON::EnumType<JsonData::StateControl::StateType>& response) const; // StateControl
         uint32_t set_state(const Core::JSON::EnumType<JsonData::StateControl::StateType>& param); // StateControl
         uint32_t endpoint_delete(const JsonData::Browser::DeleteParamsData& params);
+        uint32_t get_languages(Core::JSON::ArrayType<Core::JSON::String>& response) const;
+        uint32_t set_languages(const Core::JSON::ArrayType<Core::JSON::String>& param);
+        uint32_t get_headers(Core::JSON::ArrayType<JsonData::WebKitBrowser::HeadersData>& response) const;
+        uint32_t set_headers(const Core::JSON::ArrayType<JsonData::WebKitBrowser::HeadersData>& param);        
+        void event_bridgequery(const string& message);
         void event_statechange(const bool& suspended); // StateControl
 
     private:
@@ -230,6 +238,7 @@ namespace Plugin {
         PluginHost::IShell* _service;
         Exchange::IWebBrowser* _browser;
         Exchange::IMemory* _memory;
+        Exchange::IApplication* _application;
         Core::Sink<Notification> _notification;
         Core::ProxyPoolType<Web::JSONBodyType<WebKitBrowser::Data>> _jsonBodyDataFactory;
         string _persistentStoragePath;

--- a/WebKitBrowser/WebKitBrowserJsonRpc.cpp
+++ b/WebKitBrowser/WebKitBrowserJsonRpc.cpp
@@ -38,12 +38,16 @@ namespace Plugin {
     void WebKitBrowser::RegisterAll()
     {
         Property<Core::JSON::EnumType<StateType>>(_T("state"), &WebKitBrowser::get_state, &WebKitBrowser::set_state, this); /* StateControl */
+        Property<Core::JSON::ArrayType<Core::JSON::String>>(_T("languages"), &WebKitBrowser::get_languages, &WebKitBrowser::set_languages, this);
+        Property<Core::JSON::ArrayType<JsonData::WebKitBrowser::HeadersData>>(_T("headers"), &WebKitBrowser::get_headers, &WebKitBrowser::set_headers, this);
         Register<DeleteParamsData,void>(_T("delete"), &WebKitBrowser::endpoint_delete, this);
     }
 
     void WebKitBrowser::UnregisterAll()
     {
         Unregister(_T("state"));
+        Unregister(_T("headers"));
+        Unregister(_T("languages"));        
         Unregister(_T("delete"));
     }
 
@@ -56,6 +60,66 @@ namespace Plugin {
     uint32_t WebKitBrowser::endpoint_delete(const DeleteParamsData& params)
     {
         return DeleteDir(params.Path.Value());
+    }
+
+    // Property: languages - Browser prefered languages
+    // Return codes:
+    //  - ERROR_NONE: Success
+    uint32_t WebKitBrowser::get_languages(Core::JSON::ArrayType<Core::JSON::String>& response) const
+    {
+        ASSERT(_application != nullptr);
+
+        string langs;
+        static_cast<const IApplication*>(_application)->Language(langs);
+        response.FromString(langs);
+
+        return Core::ERROR_NONE;
+    }
+
+    // Property: languages - Browser prefered languages
+    // Return codes:
+    //  - ERROR_NONE: Success
+    uint32_t WebKitBrowser::set_languages(const Core::JSON::ArrayType<Core::JSON::String>& param)
+    {
+        ASSERT(_application != nullptr);
+
+        string langs;
+        if ( param.IsSet() ) {
+            param.ToString(langs);
+        }
+        _application->Language(static_cast<const string>(langs));
+
+        return Core::ERROR_NONE;
+    }
+
+    // Property: headers - Headers to send on all requests that the browser makes
+    // Return codes:
+    //  - ERROR_NONE: Success
+    uint32_t WebKitBrowser::get_headers(Core::JSON::ArrayType<JsonData::WebKitBrowser::HeadersData>& response) const
+    {
+        ASSERT(_browser != nullptr);
+        string headers;
+        static_cast<const IWebBrowser*>(_browser)->HeaderList(headers);
+
+        response.FromString(headers);
+        return Core::ERROR_NONE;
+    }
+
+    // Property: headers - Headers to send on all requests that the browser makes
+    // Return codes:
+    //  - ERROR_NONE: Success
+    uint32_t WebKitBrowser::set_headers(const Core::JSON::ArrayType<JsonData::WebKitBrowser::HeadersData>& param)
+    {
+        ASSERT(_browser != nullptr);
+
+        string headers;
+
+        if ( param.IsSet() ) {
+            param.ToString(headers);
+        }
+
+        _browser->HeaderList(static_cast<const string>(headers));
+        return Core::ERROR_NONE;
     }
 
     // Property: state - Running state of the service
@@ -112,6 +176,14 @@ namespace Plugin {
         params.Suspended = suspended;
 
         Notify(_T("statechange"), params);
+    }
+
+    // Event: bridgequery - A message from legacy $badger bridge
+    void WebKitBrowser::event_bridgequery(const string& message)
+    {
+        Core::JSON::String params;
+        params = message;
+        Notify(_T("bridgequery"), params);
     }
 
 } // namespace Plugin

--- a/WebKitBrowser/WebKitBrowserPlugin.json
+++ b/WebKitBrowser/WebKitBrowserPlugin.json
@@ -123,7 +123,8 @@
       "locator"
     ]
   },
-  "interface": {
-    "$cppref": "{cppinterfacedir}/IBrowser.h"
-  }
+  "interface": [ 
+   { "$cppref": "{cppinterfacedir}/IBrowser.h" },
+   { "$ref": "{interfacedir}/WebKitBrowser.json#" }
+  ]
 }

--- a/WebKitBrowser/WebKitImplementation.cpp
+++ b/WebKitBrowser/WebKitImplementation.cpp
@@ -346,7 +346,11 @@ static GSourceFuncs _handlerIntervention =
         }
     }
 
-    class WebKitImplementation : public Core::Thread, public Exchange::IBrowser, public Exchange::IWebBrowser, public PluginHost::IStateControl {
+    class WebKitImplementation : public Core::Thread, 
+                                 public Exchange::IBrowser, 
+                                 public Exchange::IWebBrowser, 
+                                 public Exchange::IApplication,
+                                 public PluginHost::IStateControl {
     public:
         class BundleConfig : public Core::JSON::Container {
         private:
@@ -721,6 +725,7 @@ static GSourceFuncs _handlerIntervention =
             , _notificationClients()
             , _notificationBrowserClients()
             , _stateControlClients()
+            , _applicationClients()
             , _state(PluginHost::IStateControl::UNINITIALIZED)
             , _hidden(false)
             , _time(0)
@@ -756,19 +761,19 @@ static GSourceFuncs _handlerIntervention =
         }
 
     public:
-        uint32_t Headers(string& headers) const override
+        uint32_t HeaderList(string& headerlist) const override
         {
             _adminLock.Lock();
-            headers = _headers;
+            headerlist = _headers;
             _adminLock.Unlock();
             return Core::ERROR_NONE;
         }
 
-        uint32_t Headers(const string& headers) override
+        uint32_t HeaderList(const string& headerlist) override
         {
             if (_context != nullptr) {
                 using SetHeadersData = std::tuple<WebKitImplementation*, string>;
-                auto* data = new SetHeadersData(this, headers);
+                auto* data = new SetHeadersData(this, headerlist);
 
                 g_main_context_invoke_full(
                     _context,
@@ -847,78 +852,6 @@ static GSourceFuncs _handlerIntervention =
                 data,
                 [](gpointer customdata) {
                     delete static_cast<SetUserAgentData*>(customdata);
-                });
-
-            return Core::ERROR_NONE;
-        }
-        uint32_t Languages(string& langs) const override
-        {
-            _adminLock.Lock();
-            Core::JSON::ArrayType<Core::JSON::String> langsArray = _config.Languages;
-            _adminLock.Unlock();
-
-            langsArray.ToString(langs);
-            return Core::ERROR_NONE;
-        }
-
-        uint32_t Languages(const string& langs) override
-        {
-            if (_context == nullptr)
-                return Core::ERROR_GENERAL;
-
-            Core::OptionalType<Core::JSON::Error> error;
-            Core::JSON::ArrayType<Core::JSON::String> array;
-
-            if (!array.FromString(langs, error)) {
-                TRACE(Trace::Error,
-                     (_T("Failed to parse languages array, error='%s', array='%s'\n"),
-                      (error.IsSet() ? error.Value().Message().c_str() : "unknown"), langs.c_str()));
-                return Core::ERROR_GENERAL;
-            }
-
-            using SetLanguagesData = std::tuple<WebKitImplementation*, Core::JSON::ArrayType<Core::JSON::String> >;
-            auto* data = new SetLanguagesData(this, array);
-            g_main_context_invoke_full(
-                _context,
-                G_PRIORITY_DEFAULT,
-                [](gpointer customdata) -> gboolean {
-                    auto& data = *static_cast<SetLanguagesData*>(customdata);
-                    WebKitImplementation* object = std::get<0>(data);
-                    Core::JSON::ArrayType<Core::JSON::String> array = std::get<1>(data);
-
-                    object->_adminLock.Lock();
-                    object->_config.Languages = array;
-                    object->_adminLock.Unlock();
-
-#ifdef WEBKIT_GLIB_API
-                    auto* languages = static_cast<char**>(g_new0(char*, array.Length() + 1));
-                    Core::JSON::ArrayType<Core::JSON::String>::Iterator index(array.Elements());
-
-                    for (unsigned i = 0; index.Next(); ++i)
-                        languages[i] = g_strdup(index.Current().Value().c_str());
-
-                    WebKitWebContext* context = webkit_web_view_get_context(object->_view);
-                    webkit_web_context_set_preferred_languages(context, languages);
-                    g_strfreev(languages);
-#else
-                    auto languages = WKMutableArrayCreate();
-                    for (auto it = array.Elements(); it.Next();) {
-                        if (!it.IsValid())
-                            continue;
-                        auto itemString = WKStringCreateWithUTF8CString(it.Current().Value().c_str());
-                        WKArrayAppendItem(languages, itemString);
-                        WKRelease(itemString);
-                    }
-
-                    auto context = WKPageGetContext(object->_page);
-                    WKSoupSessionSetPreferredLanguages(context, languages);
-                    WKRelease(languages);
-#endif
-                    return G_SOURCE_REMOVE;
-                },
-                data,
-                [](gpointer customdata) {
-                    delete static_cast<SetLanguagesData*>(customdata);
                 });
 
             return Core::ERROR_NONE;
@@ -1153,17 +1086,17 @@ static GSourceFuncs _handlerIntervention =
             return Core::ERROR_NONE;
         }
 
-        uint32_t Visible(bool& visible) const override
+        uint32_t Visibility(VisibilityType& visible) const override
         {
             _adminLock.Lock();
-            visible = !_hidden;
+            visible = (_hidden == true ? VisibilityType::HIDDEN : VisibilityType::VISIBLE);
             _adminLock.Unlock();
             return 0;
         }
 
-        uint32_t Visible(const bool visible) override
+        uint32_t Visibility(const VisibilityType visible) override
         {
-            Hide(!visible);
+            Hide(visible == VisibilityType::HIDDEN);
             return 0;
         }
 
@@ -1373,6 +1306,157 @@ static GSourceFuncs _handlerIntervention =
             _adminLock.Unlock();
         }
 
+        // IApplication implementation
+
+        void Register(Exchange::IApplication::INotification* sink) override {
+            _adminLock.Lock();
+
+            // Make sure a sink is not registered multiple times.
+            ASSERT(std::find(_applicationClients.begin(), _applicationClients.end(), sink) == _applicationClients.end());
+
+            _applicationClients.push_back(sink);
+            sink->AddRef();
+
+            _adminLock.Unlock();
+
+            TRACE(Trace::Information, (_T("Registered an IApplication sink on the browser %p"), sink));
+        }
+
+        void Unregister(Exchange::IApplication::INotification* sink) override {
+            _adminLock.Lock();
+
+            std::list<Exchange::IApplication::INotification*>::iterator index(std::find(_applicationClients.begin(), _applicationClients.end(), sink));
+
+            // Make sure you do not unregister something you did not register !!!
+            ASSERT(index != _applicationClients.end());
+
+            if (index != _applicationClients.end()) {
+                (*index)->Release();
+                _applicationClients.erase(index);
+                TRACE(Trace::Information, (_T("Unregistered an IApplication sink from the browser %p"), sink));
+            }
+
+            _adminLock.Unlock();
+        }
+
+        uint32_t Reset(const resettype type) override {
+            return Core::ERROR_UNAVAILABLE;
+        }
+
+        uint32_t Identifier(string& id) const override {
+
+            const PluginHost::ISubSystem::IIdentifier* identifier(_service->SubSystems()->Get<PluginHost::ISubSystem::IIdentifier>());
+            if (identifier != nullptr) {
+                uint8_t buffer[64];
+
+                buffer[0] = static_cast<const PluginHost::ISubSystem::IIdentifier*>(identifier)
+                            ->Identifier(sizeof(buffer) - 1, &(buffer[1]));
+
+                if (buffer[0] != 0) {
+                    id = Core::SystemInfo::Instance().Id(buffer, ~0);
+                }
+
+                identifier->Release();
+            }
+
+            return Core::ERROR_NONE;
+        }
+
+        uint32_t ContentLink(const string& link) override {
+            return Core::ERROR_UNAVAILABLE;
+        }
+
+        uint32_t LaunchPoint(launchpointtype& point) const override {
+            return Core::ERROR_UNAVAILABLE;
+        }
+
+        uint32_t LaunchPoint(const launchpointtype&) override {
+            return Core::ERROR_UNAVAILABLE;
+        }
+
+        uint32_t Visible(bool& visiblity) const override {
+            _adminLock.Lock();
+            visiblity = (_hidden == false);
+            _adminLock.Unlock();
+            return Core::ERROR_NONE;
+        }
+
+        uint32_t Visible(const bool& visiblity) override {
+            Hide(!visiblity);
+            return Core::ERROR_NONE;
+        }
+
+        uint32_t Language(string& language) const override {
+            _adminLock.Lock();
+            Core::JSON::ArrayType<Core::JSON::String> langsArray = _config.Languages;
+            _adminLock.Unlock();
+
+            langsArray.ToString(language);
+            return Core::ERROR_NONE;
+        }
+
+        uint32_t Language(const string& language) override {
+            if (_context == nullptr)
+                return Core::ERROR_GENERAL;
+
+            Core::OptionalType<Core::JSON::Error> error;
+            Core::JSON::ArrayType<Core::JSON::String> array;
+
+            if (!array.FromString(language, error)) {
+                TRACE(Trace::Error,
+                     (_T("Failed to parse languages array, error='%s', array='%s'\n"),
+                      (error.IsSet() ? error.Value().Message().c_str() : "unknown"), language.c_str()));
+                return Core::ERROR_GENERAL;
+            }
+
+            using SetLanguagesData = std::tuple<WebKitImplementation*, Core::JSON::ArrayType<Core::JSON::String> >;
+            auto* data = new SetLanguagesData(this, array);
+            g_main_context_invoke_full(
+                _context,
+                G_PRIORITY_DEFAULT,
+                [](gpointer customdata) -> gboolean {
+                    auto& data = *static_cast<SetLanguagesData*>(customdata);
+                    WebKitImplementation* object = std::get<0>(data);
+                    Core::JSON::ArrayType<Core::JSON::String> array = std::get<1>(data);
+
+                    object->_adminLock.Lock();
+                    object->_config.Languages = array;
+                    object->_adminLock.Unlock();
+
+#ifdef WEBKIT_GLIB_API
+                    auto* languages = static_cast<char**>(g_new0(char*, array.Length() + 1));
+                    Core::JSON::ArrayType<Core::JSON::String>::Iterator index(array.Elements());
+
+                    for (unsigned i = 0; index.Next(); ++i)
+                        languages[i] = g_strdup(index.Current().Value().c_str());
+
+                    WebKitWebContext* context = webkit_web_view_get_context(object->_view);
+                    webkit_web_context_set_preferred_languages(context, languages);
+                    g_strfreev(languages);
+#else
+                    auto languages = WKMutableArrayCreate();
+                    for (auto it = array.Elements(); it.Next();) {
+                        if (!it.IsValid())
+                            continue;
+                        auto itemString = WKStringCreateWithUTF8CString(it.Current().Value().c_str());
+                        WKArrayAppendItem(languages, itemString);
+                        WKRelease(itemString);
+                    }
+
+                    auto context = WKPageGetContext(object->_page);
+                    WKSoupSessionSetPreferredLanguages(context, languages);
+                    WKRelease(languages);
+#endif
+                    return G_SOURCE_REMOVE;
+                },
+                data,
+                [](gpointer customdata) {
+                    delete static_cast<SetLanguagesData*>(customdata);
+                });
+
+            return Core::ERROR_NONE;
+        }
+
         void OnURLChanged(const string& URL)
         {
             _adminLock.Lock();
@@ -1486,6 +1570,13 @@ static GSourceFuncs _handlerIntervention =
                         index++;
                     }
                 }
+                {
+                    std::list<Exchange::IApplication::INotification*>::iterator index(_applicationClients.begin());
+                    while (index != _applicationClients.end()) {
+                        (*index)->VisibilityChange(hidden);
+                        index++;
+                    }
+                }
             }
 
             _adminLock.Unlock();
@@ -1503,7 +1594,7 @@ static GSourceFuncs _handlerIntervention =
             std::list<Exchange::IWebBrowser::INotification*>::iterator index(_notificationClients.begin());
 
             while (index != _notificationClients.end()) {
-                (*index)->BridgeQuery(text);
+                (*index)->BridgeQueryResponse(text);
                 index++;
             }
 
@@ -1768,6 +1859,7 @@ static GSourceFuncs _handlerIntervention =
         BEGIN_INTERFACE_MAP(WebKitImplementation)
         INTERFACE_ENTRY(Exchange::IWebBrowser)
         INTERFACE_ENTRY(Exchange::IBrowser)
+        INTERFACE_ENTRY (Exchange::IApplication)
         INTERFACE_ENTRY(PluginHost::IStateControl)
         END_INTERFACE_MAP
 
@@ -2458,6 +2550,7 @@ static GSourceFuncs _handlerIntervention =
         std::list<Exchange::IWebBrowser::INotification*> _notificationClients;
         std::list<Exchange::IBrowser::INotification*> _notificationBrowserClients;
         std::list<PluginHost::IStateControl::INotification*> _stateControlClients;
+        std::list<Exchange::IApplication::INotification*> _applicationClients;
         PluginHost::IStateControl::state _state;
         bool _hidden;
         uint64_t _time;

--- a/WebKitBrowser/doc/WebKitBrowserPlugin.md
+++ b/WebKitBrowser/doc/WebKitBrowserPlugin.md
@@ -107,31 +107,27 @@ The table below lists configuration options of the plugin.
 
 The following methods are provided by the WebKitBrowser plugin:
 
-WebKitBrowser interface methods:
+WebBrowser interface methods:
 
 | Method | Description |
 | :-------- | :-------- |
-| [bridgereply](#method.bridgereply) | Response for legacy $badger |
-| [bridgeevent](#method.bridgeevent) | Send legacy $badger event  |
+| [collectgarbage](#method.collectgarbage) | Initiate garbage collection |
 
-Browser interface methods:
+WebKitBrowser interface methods:
 
 | Method | Description |
 | :-------- | :-------- |
 | [delete](#method.delete) | Removes contents of a directory from the persistent storage |
 
 
-<a name="method.bridgereply"></a>
-## *bridgereply <sup>method</sup>*
+<a name="method.collectgarbage"></a>
+## *collectgarbage <sup>method</sup>*
 
-Response for legacy $badger.
+Initiate garbage collection.
 
 ### Parameters
 
-| Name | Type | Description |
-| :-------- | :-------- | :-------- |
-| params | object |  |
-| params.payload | string | base64 encoded JSON string response to be delivered to $badger.callback(pid, success, json) |
+This method takes no parameters.
 
 ### Result
 
@@ -147,10 +143,7 @@ Response for legacy $badger.
 {
     "jsonrpc": "2.0",
     "id": 1234567890,
-    "method": "WebKitBrowser.1.bridgereply",
-    "params": {
-        "payload": ""
-    }
+    "method": "WebKitBrowser.1.collectgarbage"
 }
 ```
 
@@ -164,48 +157,6 @@ Response for legacy $badger.
 }
 ```
 
-<a name="method.bridgeevent"></a>
-## *bridgeevent <sup>method</sup>*
-
-Send legacy $badger event.
-
-### Parameters
-
-| Name | Type | Description |
-| :-------- | :-------- | :-------- |
-| params | object |  |
-| params.payload | string | base64 encoded JSON string response to be delivered to window.$badger.event(handlerId, json) |
-
-### Result
-
-| Name | Type | Description |
-| :-------- | :-------- | :-------- |
-| result | null | Always null |
-
-### Example
-
-#### Request
-
-```json
-{
-    "jsonrpc": "2.0",
-    "id": 1234567890,
-    "method": "WebKitBrowser.1.bridgeevent",
-    "params": {
-        "payload": ""
-    }
-}
-```
-
-#### Response
-
-```json
-{
-    "jsonrpc": "2.0",
-    "id": 1234567890,
-    "result": null
-}
-```
 <a name="method.delete"></a>
 ## *delete <sup>method</sup>*
 
@@ -269,19 +220,28 @@ WebBrowser interface properties:
 | Property | Description |
 | :-------- | :-------- |
 | [url](#property.url) | Page loaded in the browser |
-| [visible](#property.visible) | Browser window visibility state |
+| [visibility](#property.visibility) | Browser window visibility state |
 | [fps](#property.fps) <sup>RO</sup> | Current framerate the browser is rendering at |
-| [headers](#property.headers) | Headers to send on all requests that the browser makes |
+| [headerlist](#property.headerlist) | Headers to send on all requests that the browser makes |
 | [useragent](#property.useragent) | UserAgent string used by the browser |
-| [languages](#property.languages) | User preferred languages used by the browser |
 | [localstorageenabled](#property.localstorageenabled) | Controls the local storage availability |
 | [httpcookieacceptpolicy](#property.httpcookieacceptpolicy) | HTTP cookies accept policy |
+| [bridgereply](#property.bridgereply) <sup>WO</sup> | Response for legacy $badger |
+| [bridgeevent](#property.bridgeevent) <sup>WO</sup> | Send legacy $badger event |
+
+WebKitBrowser interface properties:
+
+| Property | Description |
+| :-------- | :-------- |
+| [languages](#property.languages) | User preferred languages |
+| [headers](#property.headers) | Headers to send on all requests that the browser makes |
 
 StateControl interface properties:
 
 | Property | Description |
 | :-------- | :-------- |
 | [state](#property.state) | Running state of the service |
+
 
 <a name="property.url"></a>
 ## *url <sup>property</sup>*
@@ -312,7 +272,7 @@ Provides access to the page loaded in the browser.
 {
     "jsonrpc": "2.0",
     "id": 1234567890,
-    "result": "https://www.google.com"
+    "result": "https://example.com"
 }
 ```
 
@@ -323,7 +283,7 @@ Provides access to the page loaded in the browser.
     "jsonrpc": "2.0",
     "id": 1234567890,
     "method": "WebKitBrowser.1.url",
-    "params": "https://www.google.com"
+    "params": "https://example.com"
 }
 ```
 
@@ -337,8 +297,8 @@ Provides access to the page loaded in the browser.
 }
 ```
 
-<a name="property.visible"></a>
-## *visible <sup>property</sup>*
+<a name="property.visibility"></a>
+## *visibility <sup>property</sup>*
 
 Provides access to the browser window visibility state.
 
@@ -346,7 +306,7 @@ Provides access to the browser window visibility state.
 
 | Name | Type | Description |
 | :-------- | :-------- | :-------- |
-| (property) | boolean | Visiblity state |
+| (property) | string | Visiblity state (must be one of the following: *Hidden*, *Visible*) |
 
 ### Example
 
@@ -356,7 +316,7 @@ Provides access to the browser window visibility state.
 {
     "jsonrpc": "2.0",
     "id": 1234567890,
-    "method": "WebKitBrowser.1.visible"
+    "method": "WebKitBrowser.1.visibility"
 }
 ```
 
@@ -366,7 +326,7 @@ Provides access to the browser window visibility state.
 {
     "jsonrpc": "2.0",
     "id": 1234567890,
-    "result": false
+    "result": "Hidden"
 }
 ```
 
@@ -376,8 +336,8 @@ Provides access to the browser window visibility state.
 {
     "jsonrpc": "2.0",
     "id": 1234567890,
-    "method": "WebKitBrowser.1.visible",
-    "params": false
+    "method": "WebKitBrowser.1.visibility",
+    "params": "Hidden"
 }
 ```
 
@@ -426,8 +386,8 @@ Provides access to the current framerate the browser is rendering at.
 }
 ```
 
-<a name="property.headers"></a>
-## *headers <sup>property</sup>*
+<a name="property.headerlist"></a>
+## *headerlist <sup>property</sup>*
 
 Provides access to the headers to send on all requests that the browser makes.
 
@@ -435,7 +395,7 @@ Provides access to the headers to send on all requests that the browser makes.
 
 | Name | Type | Description |
 | :-------- | :-------- | :-------- |
-| (property) | string | Header Name |
+| (property) | string | Header Names |
 
 ### Example
 
@@ -445,7 +405,7 @@ Provides access to the headers to send on all requests that the browser makes.
 {
     "jsonrpc": "2.0",
     "id": 1234567890,
-    "method": "WebKitBrowser.1.headers"
+    "method": "WebKitBrowser.1.headerlist"
 }
 ```
 
@@ -455,7 +415,7 @@ Provides access to the headers to send on all requests that the browser makes.
 {
     "jsonrpc": "2.0",
     "id": 1234567890,
-    "result": "X-Forwarded-For"
+    "result": ""
 }
 ```
 
@@ -465,8 +425,8 @@ Provides access to the headers to send on all requests that the browser makes.
 {
     "jsonrpc": "2.0",
     "id": 1234567890,
-    "method": "WebKitBrowser.1.headers",
-    "params": "X-Forwarded-For"
+    "method": "WebKitBrowser.1.headerlist",
+    "params": ""
 }
 ```
 
@@ -489,7 +449,7 @@ Provides access to the userAgent string used by the browser.
 
 | Name | Type | Description |
 | :-------- | :-------- | :-------- |
-| (property) | string | UserAgent string used by the browser |
+| (property) | string | UserAgent value |
 
 ### Example
 
@@ -521,60 +481,6 @@ Provides access to the userAgent string used by the browser.
     "id": 1234567890,
     "method": "WebKitBrowser.1.useragent",
     "params": "Mozilla/5.0 (Linux; x86_64 GNU/Linux) AppleWebKit/601.1 (KHTML, like Gecko) Version/8.0 Safari/601.1 WP"
-}
-```
-
-#### Set Response
-
-```json
-{
-    "jsonrpc": "2.0",
-    "id": 1234567890,
-    "result": "null"
-}
-```
-
-<a name="property.languages"></a>
-## *languages <sup>property</sup>*
-
-Provides access to the user preferred languages used by the browser.
-
-### Value
-
-| Name | Type | Description |
-| :-------- | :-------- | :-------- |
-| (property) | string | User preferred languages used by the browser |
-
-### Example
-
-#### Get Request
-
-```json
-{
-    "jsonrpc": "2.0",
-    "id": 1234567890,
-    "method": "WebKitBrowser.1.languages"
-}
-```
-
-#### Get Response
-
-```json
-{
-    "jsonrpc": "2.0",
-    "id": 1234567890,
-    "result": ["en-US"]
-}
-```
-
-#### Set Request
-
-```json
-{
-    "jsonrpc": "2.0",
-    "id": 1234567890,
-    "method": "WebKitBrowser.1.languages",
-    "params": ["en-US"]
 }
 ```
 
@@ -671,7 +577,7 @@ Provides access to the HTTP cookies accept policy.
 {
     "jsonrpc": "2.0",
     "id": 1234567890,
-    "result": "Always"
+    "result": "always"
 }
 ```
 
@@ -682,7 +588,205 @@ Provides access to the HTTP cookies accept policy.
     "jsonrpc": "2.0",
     "id": 1234567890,
     "method": "WebKitBrowser.1.httpcookieacceptpolicy",
-    "params": "Always"
+    "params": "always"
+}
+```
+
+#### Set Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1234567890,
+    "result": "null"
+}
+```
+
+<a name="property.bridgereply"></a>
+## *bridgereply <sup>property</sup>*
+
+Provides access to the response for legacy $badger.
+
+> This property is **write-only**.
+
+### Value
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| (property) | string | base64 encoded JSON string response to be delivered to $badger.callback |
+
+### Example
+
+#### Set Request
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1234567890,
+    "method": "WebKitBrowser.1.bridgereply",
+    "params": ""
+}
+```
+
+#### Set Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1234567890,
+    "result": "null"
+}
+```
+
+<a name="property.bridgeevent"></a>
+## *bridgeevent <sup>property</sup>*
+
+Provides access to the send legacy $badger event.
+
+> This property is **write-only**.
+
+### Value
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| (property) | string | base64 encoded JSON string response to be delivered to window.$badger.event |
+
+### Example
+
+#### Set Request
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1234567890,
+    "method": "WebKitBrowser.1.bridgeevent",
+    "params": ""
+}
+```
+
+#### Set Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1234567890,
+    "result": "null"
+}
+```
+
+<a name="property.languages"></a>
+## *languages <sup>property</sup>*
+
+Provides access to the user preferred languages.
+
+### Value
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| (property) | array | User preferred languages |
+| (property)[#] | string |  |
+
+### Example
+
+#### Get Request
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1234567890,
+    "method": "WebKitBrowser.1.languages"
+}
+```
+
+#### Get Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1234567890,
+    "result": [
+        "en-US"
+    ]
+}
+```
+
+#### Set Request
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1234567890,
+    "method": "WebKitBrowser.1.languages",
+    "params": [
+        "en-US"
+    ]
+}
+```
+
+#### Set Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1234567890,
+    "result": "null"
+}
+```
+
+<a name="property.headers"></a>
+## *headers <sup>property</sup>*
+
+Provides access to the headers to send on all requests that the browser makes.
+
+### Value
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| (property) | array | Headers to send on all requests that the browser makes |
+| (property)[#] | object |  |
+| (property)[#]?.name | string | <sup>*(optional)*</sup> Header name |
+| (property)[#]?.value | string | <sup>*(optional)*</sup> Header value |
+
+### Example
+
+#### Get Request
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1234567890,
+    "method": "WebKitBrowser.1.headers"
+}
+```
+
+#### Get Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1234567890,
+    "result": [
+        {
+            "name": "X-Forwarded-For",
+            "value": "::1"
+        }
+    ]
+}
+```
+
+#### Set Request
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1234567890,
+    "method": "WebKitBrowser.1.headers",
+    "params": [
+        {
+            "name": "X-Forwarded-For",
+            "value": "::1"
+        }
+    ]
 }
 ```
 
@@ -720,6 +824,7 @@ Also see: [statechange](#event.statechange)
     "method": "WebKitBrowser.1.state"
 }
 ```
+
 #### Get Response
 
 ```json
@@ -767,13 +872,20 @@ WebBrowser interface events:
 | [urlchange](#event.urlchange) | Signals a URL change in the browser |
 | [visibilitychange](#event.visibilitychange) | Signals a visibility change of the browser |
 | [pageclosure](#event.pageclosure) | Notifies that the web page requests to close its window |
-| [bridgequery](#event.bridgequery) | Base64 encoded JSON message from legacy $badger bridge |
+| [bridgequeryresponse](#event.bridgequeryresponse) | Base64 encoded JSON message from legacy $badger bridge |
+
+WebKitBrowser interface events:
+
+| Event | Description |
+| :-------- | :-------- |
+| [bridgequery](#event.bridgequery) | A Base64 encoded JSON message from legacy $badger bridge |
 
 StateControl interface events:
 
 | Event | Description |
 | :-------- | :-------- |
 | [statechange](#event.statechange) | Signals a state change of the service |
+
 
 <a name="event.loadfinished"></a>
 ## *loadfinished <sup>event</sup>*
@@ -786,7 +898,7 @@ Initial HTML document has been completely loaded and parsed.
 | :-------- | :-------- | :-------- |
 | params | object |  |
 | params.url | string | The URL that has been loaded |
-| params.code | integer | The response code of main resource request |
+| params.httpstatus | integer | The response code of main resource request |
 
 ### Example
 
@@ -796,7 +908,7 @@ Initial HTML document has been completely loaded and parsed.
     "method": "client.events.1.loadfinished",
     "params": {
         "url": "https://example.com",
-        "code": 200
+        "httpstatus": 200
     }
 }
 ```
@@ -893,8 +1005,8 @@ This event carries no parameters.
 }
 ```
 
-<a name="event.bridgequery"></a>
-## *bridgequery <sup>event</sup>*
+<a name="event.bridgequeryresponse"></a>
+## *bridgequeryresponse <sup>event</sup>*
 
 Base64 encoded JSON message from legacy $badger bridge.
 
@@ -910,10 +1022,31 @@ Base64 encoded JSON message from legacy $badger bridge.
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.bridgequery",
+    "method": "client.events.1.bridgequeryresponse",
     "params": {
         "message": ""
     }
+}
+```
+
+<a name="event.bridgequery"></a>
+## *bridgequery <sup>event</sup>*
+
+A Base64 encoded JSON message from legacy $badger bridge.
+
+### Parameters
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| params | string |  |
+
+### Example
+
+```json
+{
+    "jsonrpc": "2.0",
+    "method": "client.events.1.bridgequery",
+    "params": ""
 }
 ```
 
@@ -940,3 +1073,4 @@ Signals a state change of the service.
     }
 }
 ```
+


### PR DESCRIPTION

This updates the WebBrowser json rpc interface to be gererated (as much as possible) from the IWebBrowser interface while remaining backwards compatible with the already published json rpc interface (that was at that time generated from the json meta file instead of the C++ header file)

Also a first integration of the IApplication interface to WebKit was done but it is not yet complete and there will be no json rpc interface generated for it. 

Please note that these changes will (to some extend) break the current COM RPC interface and the json rpc interface generated from the IBrowser.h file.

The following pull request all belong to this and must be submitted together:

https://github.com/WebPlatformForEmbedded/ThunderNanoServicesRDK/pull/39
https://github.com/rdkcentral/ThunderInterfaces/pull/41
https://github.com/rdkcentral/Thunder/pull/524

For the HeaderList method no example value is yet added to the header file (and therefore also not included to the documentation) as the json rpc generator needs to be extended to be able to handle the content for that