### PR TITLE
Don't use std::make_pair

### DIFF
--- a/TraceControl/TraceControl.cpp
+++ b/TraceControl/TraceControl.cpp
@@ -167,9 +167,7 @@ namespace {
 
             if ((_maxExportConnections !=0) && (_maxExportConnections - _traceChannelOutputs.size() > 0)) {
                 ASSERT(0 == _traceChannelOutputs.count(channel.Id()));
-                _traceChannelOutputs.emplace(std::make_pair(channel.Id(), new TraceChannelOutput(channel)));
-                accepted = true;
-
+                _traceChannelOutputs.emplace(std::piecewise_construct, std::forward_as_tuple(channel.Id()), std::forward_as_tuple(WebSocketExporter::TraceChannelOutputPtr(new WebSocketExporter::TraceChannelOutput(channel))));
             }
 
             _lock.Unlock();


### PR DESCRIPTION
Seems like std::make_pair is not fully
implemented on GCC <= 5.4.0 resulting in the
compilation errors. This is changed to use
piecewise_construct as in other places in the
framework.