### PR TITLE
[SecurityAgent] Delete dispatcher in plugin deinitialization

### DIFF
--- a/SecurityAgent/SecurityAgent.cpp
+++ b/SecurityAgent/SecurityAgent.cpp
@@ -144,6 +144,8 @@ namespace Plugin {
 
         ASSERT(subSystem != nullptr);
 
+        _dispatcher.reset(nullptr);
+        
         if (subSystem != nullptr) {
             subSystem->Set(PluginHost::ISubSystem::NOT_SECURITY, nullptr);
             subSystem->Release();


### PR DESCRIPTION
Destroy RPC dispatcher on Deinitialize. Already fixed on master.