### PR TITLE
LocationSync: Double the Receive Buffer Size to handle the ip-papi.com response with out buffering

### DIFF
--- a/LocationSync/LocationService.cpp
+++ b/LocationSync/LocationService.cpp
@@ -326,7 +326,7 @@ namespace Plugin {
 
 PUSH_WARNING(DISABLE_WARNING_THIS_IN_MEMBER_INITIALIZER_LIST)
     LocationService::LocationService(Core::IDispatchType<void>* callback)
-        : BaseClass(1, g_Factory, false, Core::NodeId(), Core::NodeId(), 256, 1024)
+        : BaseClass(1, g_Factory, false, Core::NodeId(), Core::NodeId(), 256, (1024 * 2))
         , _adminLock()
         , _state(IDLE)
         , _remoteId()


### PR DESCRIPTION
Details are mentioned in the ticket: https://jira.rdkcentral.com/jira/browse/METROL-500