### PR TITLE
DeviceIdentification: Remove redundant header and class inheritance

### DIFF
--- a/DeviceIdentification/Implementation/Amlogic/Amlogic.cpp
+++ b/DeviceIdentification/Implementation/Amlogic/Amlogic.cpp
@@ -4,7 +4,7 @@
 
 namespace WPEFramework {
 namespace Plugin {
-    class DeviceImplementation : public Exchange::IDeviceProperties, public PluginHost::ISubSystem::IIdentifier {
+    class DeviceImplementation : public PluginHost::ISubSystem::IIdentifier {
 	    static constexpr const TCHAR* ChipsetInfo= _T("T962X3");
         static constexpr const TCHAR* VERSIONFile = _T("/version.txt");
 
@@ -52,7 +52,6 @@ namespace Plugin {
         }
 
         BEGIN_INTERFACE_MAP(DeviceImplementation)
-        INTERFACE_ENTRY(Exchange::IDeviceProperties)
         INTERFACE_ENTRY(PluginHost::ISubSystem::IIdentifier)
         END_INTERFACE_MAP
 

--- a/DeviceIdentification/Implementation/Broadcom/Broadcom.cpp
+++ b/DeviceIdentification/Implementation/Broadcom/Broadcom.cpp
@@ -18,7 +18,6 @@
  */
  
 #include "../../Module.h"
-#include <interfaces/IDeviceIdentification.h>
 
 #include <fstream>
 


### PR DESCRIPTION
based on testing with rdkservices sync-up found IDeviceProperties is making compile error.