### PR TITLE
[PerfMetrix] support metrics on classname

### DIFF
--- a/PerformanceMetrics/PerformanceMetrics.cpp
+++ b/PerformanceMetrics/PerformanceMetrics.cpp
@@ -72,18 +72,18 @@ namespace Plugin {
         return (_T(""));
     }
 
-    void PerformanceMetrics::PluginActivated(PluginHost::IShell& service, const string& callsign) 
+    void PerformanceMetrics::PluginActivated(PluginHost::IShell& service) 
     {
         ASSERT(_handler);
 
-        _handler->Activated(service, callsign);
+        _handler->Activated(service);
     }
 
-    void PerformanceMetrics::PluginDeactivated(PluginHost::IShell& service, const string& callsign) 
+    void PerformanceMetrics::PluginDeactivated(PluginHost::IShell& service) 
     {
         ASSERT(_handler);
 
-        _handler->Deactivated(service, callsign);
+        _handler->Deactivated(service);
     }
 
     void PerformanceMetrics::CallsignPerfMetricsHandler::CreateObservable(PluginHost::IShell& service)


### PR DESCRIPTION
Next to getting the performance metrics for a single plugin (given its callsign) now performance metrics for all plugins of a given classname are supported.