### PR TITLE
FindWPEWebKit.cmake: Allow picking WebKit 2.38 with soup3

### DIFF
--- a/WebKitBrowser/cmake/FindWPEWebKit.cmake
+++ b/WebKitBrowser/cmake/FindWPEWebKit.cmake
@@ -27,18 +27,12 @@
 
 find_package(PkgConfig)
 
-if (NOT PC_WPE_WEBKIT_FOUND)
-pkg_check_modules(PC_WPE_WEBKIT wpe-webkit-1.0)
-endif()
-
-if (NOT PC_WPE_WEBKIT_FOUND)
-pkg_check_modules(PC_WPE_WEBKIT wpe-webkit-0.1)
-endif()
-
-# Support old, non-versioned pc
-if (NOT PC_WPE_WEBKIT_FOUND)
-pkg_check_modules(PC_WPE_WEBKIT wpe-webkit)
-endif()
+pkg_search_module(PC_WPE_WEBKIT QUIET
+    wpe-webkit-1.1>=2.38.0
+    wpe-webkit-1.0
+    wpe-webkit-0.1
+    wpe-webkit
+)
 
 if (PC_WPE_WEBKIT_FOUND)
     set(WPE_WEBKIT_FOUND TRUE)


### PR DESCRIPTION
Add `wpe-webkit-1.1` as usable pkg-config module. This corresponds to recent WPE WebKit versions built with soup3. While at it, switch over to `pkg_search_module()` which will pick the first module found from the list passed to it.