### PR TITLE
[WebKitBrowser] Adding two missing Locks

### DIFF
--- a/WebKitBrowser/WebKitBrowser.cpp
+++ b/WebKitBrowser/WebKitBrowser.cpp
@@ -411,6 +411,9 @@ namespace WebKitBrowser {
             uint32_t result(0);
 
             if (_startTime != TimePoint::min()) {
+
+                _adminLock.Lock();
+
                 if (_children.Count() < RequiredChildren) {
                     _children = Core::ProcessInfo::Iterator(_main.Id());
                 }
@@ -435,6 +438,9 @@ namespace WebKitBrowser {
             uint32_t result(0);
 
             if (_startTime != TimePoint::min()) {
+
+                _adminLock.Lock();
+
                 if (_children.Count() < RequiredChildren) {
                     _children = Core::ProcessInfo::Iterator(_main.Id());
                 }


### PR DESCRIPTION
Fixing the issue where this TRACE (https://github.com/rdkcentral/Thunder/blob/master/Source/core/Sync.h#L77) from Sync.h was constantly showing up, because the Unlock() method was called without a Lock() before that.