### PR TITLE
[Messaging] Adding a functionality to the MessageControl plugin to handle redirected standard out and error

### DIFF
--- a/LocationSync/LocationSync.cpp
+++ b/LocationSync/LocationSync.cpp
@@ -268,6 +268,11 @@ POP_WARNING()
 
         Exchange::JTimeZone::Event::TimeZoneChanged(const_cast<PluginHost::JSONRPC&>(static_cast<const PluginHost::JSONRPC&>(*this)), timezone);
         SYSLOG(Logging::Startup, (_T("TimeZone change to \"%s\", local date time is now %s."), timezone.c_str(), Core::Time::Now().ToRFC1123(true).c_str()));
+        // TO-DO: Don't forget to remove the lines below when it work, as they are just for testing
+        REPORT_OUTOFBOUNDS_WARNING(WarningReporting::TooLongWaitingForLock, 3000);
+        printf("@ [STDOUT] Testing Operational Streams - StandardOut category, LocationSync::NotifyTimeZoneChanged()\n");
+        fprintf(stderr, "@ [STDERR] Testing Operational Streams - StandardError category, LocationSync::NotifyTimeZoneChanged()\n");
+        fflush(stderr);
     }
 
     void LocationSync::SetLocationSubsystem(PluginHost::ISubSystem& subsystem, bool update) /* cannot be const due to subsystem Set*/ {

--- a/LocationSync/LocationSync.cpp
+++ b/LocationSync/LocationSync.cpp
@@ -268,11 +268,6 @@ POP_WARNING()
 
         Exchange::JTimeZone::Event::TimeZoneChanged(const_cast<PluginHost::JSONRPC&>(static_cast<const PluginHost::JSONRPC&>(*this)), timezone);
         SYSLOG(Logging::Startup, (_T("TimeZone change to \"%s\", local date time is now %s."), timezone.c_str(), Core::Time::Now().ToRFC1123(true).c_str()));
-        // TO-DO: Don't forget to remove the lines below when it work, as they are just for testing
-        REPORT_OUTOFBOUNDS_WARNING(WarningReporting::TooLongWaitingForLock, 3000);
-        printf("@ [STDOUT] Testing Operational Streams - StandardOut category, LocationSync::NotifyTimeZoneChanged()\n");
-        fprintf(stderr, "@ [STDERR] Testing Operational Streams - StandardError category, LocationSync::NotifyTimeZoneChanged()\n");
-        fflush(stderr);
     }
 
     void LocationSync::SetLocationSubsystem(PluginHost::ISubSystem& subsystem, bool update) /* cannot be const due to subsystem Set*/ {

--- a/MessageControl/MessageControl.cpp
+++ b/MessageControl/MessageControl.cpp
@@ -73,8 +73,7 @@ namespace WPEFramework {
         , _tracingFactory()
         , _loggingFactory()
         , _warningReportingFactory()
-        , _standardOutFactory()
-        , _standardErrorFactory()
+        , _operationalStreamFactory()
     {
         _client.AddInstance(0);
         _client.AddFactory(Core::Messaging::Metadata::type::TRACING, &_tracingFactory);

--- a/MessageControl/MessageControl.cpp
+++ b/MessageControl/MessageControl.cpp
@@ -80,8 +80,7 @@ namespace WPEFramework {
         _client.AddFactory(Core::Messaging::Metadata::type::TRACING, &_tracingFactory);
         _client.AddFactory(Core::Messaging::Metadata::type::LOGGING, &_loggingFactory);
         _client.AddFactory(Core::Messaging::Metadata::type::REPORTING, &_warningReportingFactory);
-        _client.AddFactory(Core::Messaging::Metadata::type::STANDARD_OUT, &_standardOutFactory);
-        _client.AddFactory(Core::Messaging::Metadata::type::STANDARD_ERROR, &_standardErrorFactory);
+        _client.AddFactory(Core::Messaging::Metadata::type::OPERATIONAL_STREAM, &_operationalStreamFactory);
     }
 
     const string MessageControl::Initialize(PluginHost::IShell* service)

--- a/MessageControl/MessageControl.cpp
+++ b/MessageControl/MessageControl.cpp
@@ -73,11 +73,15 @@ namespace WPEFramework {
         , _tracingFactory()
         , _loggingFactory()
         , _warningReportingFactory()
+        , _standardOutFactory()
+        , _standardErrorFactory()
     {
         _client.AddInstance(0);
         _client.AddFactory(Core::Messaging::Metadata::type::TRACING, &_tracingFactory);
         _client.AddFactory(Core::Messaging::Metadata::type::LOGGING, &_loggingFactory);
         _client.AddFactory(Core::Messaging::Metadata::type::REPORTING, &_warningReportingFactory);
+        _client.AddFactory(Core::Messaging::Metadata::type::STANDARD_OUT, &_standardOutFactory);
+        _client.AddFactory(Core::Messaging::Metadata::type::STANDARD_ERROR, &_standardErrorFactory);
     }
 
     const string MessageControl::Initialize(PluginHost::IShell* service)

--- a/MessageControl/MessageControl.h
+++ b/MessageControl/MessageControl.h
@@ -442,8 +442,7 @@ namespace Plugin {
         Messaging::TraceFactoryType<Core::Messaging::IStore::Tracing, Messaging::TextMessage> _tracingFactory;
         Messaging::TraceFactoryType<Core::Messaging::IStore::Logging, Messaging::TextMessage> _loggingFactory;
         Messaging::TraceFactoryType<Core::Messaging::IStore::WarningReporting, Messaging::TextMessage> _warningReportingFactory;
-        Messaging::TraceFactoryType<Core::Messaging::IStore::StandardOut, Messaging::TextMessage> _standardOutFactory;
-        Messaging::TraceFactoryType<Core::Messaging::IStore::StandardError, Messaging::TextMessage> _standardErrorFactory;
+        Messaging::TraceFactoryType<Core::Messaging::IStore::OperationalStream, Messaging::TextMessage> _operationalStreamFactory;
         Cleanups _cleaning;
     };
 

--- a/MessageControl/MessageControl.h
+++ b/MessageControl/MessageControl.h
@@ -442,6 +442,8 @@ namespace Plugin {
         Messaging::TraceFactoryType<Core::Messaging::IStore::Tracing, Messaging::TextMessage> _tracingFactory;
         Messaging::TraceFactoryType<Core::Messaging::IStore::Logging, Messaging::TextMessage> _loggingFactory;
         Messaging::TraceFactoryType<Core::Messaging::IStore::WarningReporting, Messaging::TextMessage> _warningReportingFactory;
+        Messaging::TraceFactoryType<Core::Messaging::IStore::StandardOut, Messaging::TextMessage> _standardOutFactory;
+        Messaging::TraceFactoryType<Core::Messaging::IStore::StandardError, Messaging::TextMessage> _standardErrorFactory;
         Cleanups _cleaning;
     };
 

--- a/MessageControl/MessageOutput.cpp
+++ b/MessageControl/MessageOutput.cpp
@@ -69,17 +69,17 @@ namespace Publishers {
                 data.Module = metadata.Module();
             }
 
+            const Core::Time now(metadata.TimeStamp());
+            if ((AsNumber(options) & AsNumber(ExtraOutputOptions::INCLUDINGDATE)) != 0) {
+                data.Time = now.ToRFC1123(true);
+            }
+            else {
+                data.Time = now.ToTimeOnly(true);
+            }
+
             if (metadata.Type() == Core::Messaging::Metadata::type::TRACING) {
                 ASSERT(dynamic_cast<const Core::Messaging::IStore::Tracing*>(&metadata) != nullptr);
                 const Core::Messaging::IStore::Tracing& trace = static_cast<const Core::Messaging::IStore::Tracing&>(metadata);
-                const Core::Time now(trace.TimeStamp());
-
-                if ((AsNumber(options) & AsNumber(ExtraOutputOptions::INCLUDINGDATE)) != 0) {
-                    data.Time = now.ToRFC1123(true);
-                }
-                else {
-                    data.Time = now.ToTimeOnly(true);
-                }
 
                 if ((AsNumber(options) & AsNumber(ExtraOutputOptions::FILENAME)) != 0) {
                     data.FileName = trace.FileName();
@@ -93,29 +93,9 @@ namespace Publishers {
                     data.ClassName = trace.ClassName();
                 }
             }
-            else if (metadata.Type() == Core::Messaging::Metadata::type::LOGGING) {
-                ASSERT(dynamic_cast<const Core::Messaging::IStore::Logging*>(&metadata) != nullptr);
-                const Core::Messaging::IStore::Logging& log = static_cast<const Core::Messaging::IStore::Logging&>(metadata);
-                const Core::Time now(log.TimeStamp());
-
-                if ((AsNumber(options) & AsNumber(ExtraOutputOptions::INCLUDINGDATE)) != 0) {
-                    data.Time = now.ToRFC1123(true);
-                }
-                else {
-                    data.Time = now.ToTimeOnly(true);
-                }
-            }
             else if (metadata.Type() == Core::Messaging::Metadata::type::REPORTING) {
                 ASSERT(dynamic_cast<const Core::Messaging::IStore::WarningReporting*>(&metadata) != nullptr);
                 const Core::Messaging::IStore::WarningReporting& report = static_cast<const Core::Messaging::IStore::WarningReporting&>(metadata);
-                const Core::Time now(report.TimeStamp());
-
-                if ((AsNumber(options) & AsNumber(ExtraOutputOptions::INCLUDINGDATE)) != 0) {
-                    data.Time = now.ToRFC1123(true);
-                }
-                else {
-                    data.Time = now.ToTimeOnly(true);
-                }
 
                 if ((AsNumber(options) & AsNumber(ExtraOutputOptions::CALLSIGN)) != 0) {
                     data.Callsign = report.Callsign();

--- a/MessageControl/MessageOutput.cpp
+++ b/MessageControl/MessageOutput.cpp
@@ -35,7 +35,7 @@ namespace Publishers {
 
     void ConsoleOutput::Message(const Core::Messaging::MessageInfo& metadata, const string& text) /* override */
     {
-        std::cout << _convertor.Convert(metadata, text);
+        Messaging::ConsoleStandardOut::Instance().Format(_convertor.Convert(metadata, text).c_str());
     }
 
     void SyslogOutput::Message(const Core::Messaging::MessageInfo& metadata, const string& text) /* override */
@@ -43,7 +43,7 @@ namespace Publishers {
 #ifndef __WINDOWS__
         syslog(LOG_NOTICE, _T("%s"), _convertor.Convert(metadata, text).c_str());
 #else
-        printf(_T("%s"), _convertor.Convert(metadata, text).c_str());
+        Messaging::ConsoleStandardOut::Instance().Format(_convertor.Convert(metadata, text).c_str());
 #endif
     }
 


### PR DESCRIPTION
It requires this PR to Thunder to be merged first: https://github.com/rdkcentral/Thunder/pull/1415