### PR TITLE
[MessageControl] Updating MessageControl to match the new message buffers size changes

### DIFF
--- a/MessageControl/MessageControl.h
+++ b/MessageControl/MessageControl.h
@@ -260,7 +260,7 @@ namespace Plugin {
                         index++;
                     }
                 }
-				
+
                 _adminLock.Unlock();
 
                 for (const uint32_t& id : detaching) {

--- a/MessageControl/MessageOutput.cpp
+++ b/MessageControl/MessageOutput.cpp
@@ -111,12 +111,15 @@ namespace Publishers {
 
     //UDPOutput
     UDPOutput::Channel::Channel(const Core::NodeId& nodeId)
-        : Core::SocketDatagram(false, nodeId.Origin(), nodeId, Messaging::MessageUnit::DataSize, 0)
+        : Core::SocketDatagram(false, nodeId.Origin(), nodeId, Messaging::MessageUnit::Instance().DataSize(), 0)
+        , _dataSize(Messaging::MessageUnit::Instance().DataSize())
+        , _sendBuffer(static_cast<uint8_t*>(::malloc(_dataSize)))
         , _loaded(0)
     {
     }
     UDPOutput::Channel::~Channel() {
         Close(Core::infinite);
+        free(_sendBuffer);
     }
 
     uint16_t UDPOutput::Channel::SendData(uint8_t* dataFrame, const uint16_t maxSendSize)
@@ -148,8 +151,8 @@ namespace Publishers {
         uint16_t length = 0;
         ASSERT(metadata.Type() != Core::Messaging::Metadata::INVALID);
 
-        length += metadata.Serialize(_sendBuffer + length, sizeof(_sendBuffer) - length);
-        length += message->Serialize(_sendBuffer + length, sizeof(_sendBuffer) - length);
+        length += metadata.Serialize(_sendBuffer + length, _dataSize - length);
+        length += message->Serialize(_sendBuffer + length, _dataSize - length);
         _loaded = length;
 
         _adminLock.Unlock();

--- a/MessageControl/MessageOutput.cpp
+++ b/MessageControl/MessageOutput.cpp
@@ -112,14 +112,11 @@ namespace Publishers {
     //UDPOutput
     UDPOutput::Channel::Channel(const Core::NodeId& nodeId)
         : Core::SocketDatagram(false, nodeId.Origin(), nodeId, Messaging::MessageUnit::Instance().DataSize(), 0)
-        , _dataSize(Messaging::MessageUnit::Instance().DataSize())
-        , _sendBuffer(static_cast<uint8_t*>(::malloc(_dataSize)))
         , _loaded(0)
     {
     }
     UDPOutput::Channel::~Channel() {
         Close(Core::infinite);
-        free(_sendBuffer);
     }
 
     uint16_t UDPOutput::Channel::SendData(uint8_t* dataFrame, const uint16_t maxSendSize)
@@ -151,8 +148,8 @@ namespace Publishers {
         uint16_t length = 0;
         ASSERT(metadata.Type() != Core::Messaging::Metadata::INVALID);
 
-        length += metadata.Serialize(_sendBuffer + length, _dataSize - length);
-        length += message->Serialize(_sendBuffer + length, _dataSize - length);
+        length += metadata.Serialize(_sendBuffer + length, sizeof(_sendBuffer) - length);
+        length += message->Serialize(_sendBuffer + length, sizeof(_sendBuffer) - length);
         _loaded = length;
 
         _adminLock.Unlock();

--- a/MessageControl/MessageOutput.h
+++ b/MessageControl/MessageOutput.h
@@ -326,8 +326,7 @@ namespace Publishers {
             uint16_t ReceiveData(uint8_t*, const uint16_t) override;
             void StateChange() override;
 
-            uint32_t _dataSize;
-            uint8_t* _sendBuffer;
+            uint8_t _sendBuffer[Messaging::MessageUnit::TempDataBufferSize];
             uint16_t _loaded;
             Core::CriticalSection _adminLock;
         };

--- a/MessageControl/MessageOutput.h
+++ b/MessageControl/MessageOutput.h
@@ -326,7 +326,8 @@ namespace Publishers {
             uint16_t ReceiveData(uint8_t*, const uint16_t) override;
             void StateChange() override;
 
-            uint8_t _sendBuffer[Messaging::MessageUnit::DataSize];
+            uint32_t _dataSize;
+            uint8_t* _sendBuffer;
             uint16_t _loaded;
             Core::CriticalSection _adminLock;
         };

--- a/WebKitBrowser/BrowserConsoleLog.h
+++ b/WebKitBrowser/BrowserConsoleLog.h
@@ -37,7 +37,7 @@ public:
     BrowserConsoleLog(const string& prefix, const string& message, const uint64_t line, const uint64_t column)
     {
         _text = '[' + prefix + "][" + Core::NumberType<uint64_t>(line).Text() + ',' + Core::NumberType<uint64_t>(column).Text() + ']' + message;
-        const uint16_t maxStringLength = Messaging::MessageUnit::DataSize - 1;
+        const uint16_t maxStringLength = Messaging::MessageUnit::Instance().DataSize() - 1;
         if (_text.length() > maxStringLength) {
             _text = _text.substr(0, maxStringLength);
         }
@@ -46,7 +46,7 @@ public:
     BrowserConsoleLog(const string& prefix, const WKStringRef message, const uint64_t line, const uint64_t column)
     { 
         _text = '[' + prefix + "][" + Core::NumberType<uint64_t>(line).Text() + ',' + Core::NumberType<uint64_t>(column).Text() + ']' + WebKit::Utils::WKStringToString(message);
-        const uint16_t maxStringLength = Messaging::MessageUnit::DataSize - 1;
+        const uint16_t maxStringLength = Messaging::MessageUnit::Instance().DataSize() - 1;
         if (_text.length() > maxStringLength) {
             _text = _text.substr(0, maxStringLength);
         }


### PR DESCRIPTION
This PR has to be merged first: https://github.com/rdkcentral/Thunder/pull/1548