### PR TITLE
[Actions] Adding MessageControl to be built under Windows

### DIFF
--- a/.github/workflows/Build ThunderNanoServicesRDK on Windows.yml
+++ b/.github/workflows/Build ThunderNanoServicesRDK on Windows.yml
@@ -3,7 +3,7 @@ name: Build ThunderNanoServicesRDK on Windows
 on:
   workflow_dispatch:
   push:
-    branches: ["master"]
+    # branches: ["master"]
   pull_request:
     branches: ["master"]
 
@@ -11,6 +11,7 @@ env:
   devEnv: C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\IDE\devenv.com
   deviceInfo: ThunderNanoServicesRDK\DeviceInfo\DeviceInfo.vcxproj
   locationSync: ThunderNanoServicesRDK\LocationSync\LocationSync.vcxproj
+  messageControl: ThunderNanoServicesRDK\MessageControl\MessageControl.vcxproj
   messenger: ThunderNanoServicesRDK\Messenger\Messenger.vcxproj
   monitor: ThunderNanoServicesRDK\Monitor\Monitor.vcxproj
   openCDMi: ThunderNanoServicesRDK\OpenCDMi\OpenCDMi.vcxproj
@@ -81,6 +82,7 @@ jobs:
         cd ThunderOnWindows
         && "%devEnv%" /Build "${{matrix.type}}|x${{matrix.version}}" /Project "%deviceInfo%"  "%solution%"
         && "%devEnv%" /Build "${{matrix.type}}|x${{matrix.version}}" /Project "%locationSync%"  "%solution%"
+        && "%devEnv%" /Build "${{matrix.type}}|x${{matrix.version}}" /Project "%messageControl%"  "%solution%"
         && "%devEnv%" /Build "${{matrix.type}}|x${{matrix.version}}" /Project "%messenger%"  "%solution%"
         && "%devEnv%" /Build "${{matrix.type}}|x${{matrix.version}}" /Project "%monitor%"  "%solution%"
         && "%devEnv%" /Build "${{matrix.type}}|x${{matrix.version}}" /Project "%openCDMi%"  "%solution%"

--- a/.github/workflows/Build ThunderNanoServicesRDK on Windows.yml
+++ b/.github/workflows/Build ThunderNanoServicesRDK on Windows.yml
@@ -3,7 +3,7 @@ name: Build ThunderNanoServicesRDK on Windows
 on:
   workflow_dispatch:
   push:
-    # branches: ["master"]
+    branches: ["master"]
   pull_request:
     branches: ["master"]
 


### PR DESCRIPTION
First, I needed to add the MessageControl to the solution file on Windows, alongside with its dependencies in this commit: https://github.com/WebPlatformForEmbedded/ThunderOnWindows/commit/bb4ecbd5aa713f8cf9eb5b21f63d65eaae16c0b3