### PR TITLE
[MessageControl] Fixing UDP output and allowing it to store more than one message

### DIFF
--- a/MessageControl/MessageControl.cpp
+++ b/MessageControl/MessageControl.cpp
@@ -114,7 +114,7 @@ namespace Thunder {
             Announce(new Publishers::FileOutput(abbreviate, _config.FileName.Value()));
         }
         if ((_config.Remote.Binding.Value().empty() == false) && (_config.Remote.Port.Value() != 0)) {
-            Announce(new Publishers::UDPOutput(Core::NodeId(_config.Remote.NodeId())));
+            Announce(new Publishers::UDPOutput(abbreviate, Core::NodeId(_config.Remote.NodeId())));
         }
 
         _webSocketExporter.Initialize(service, _config.MaxExportConnections.Value());

--- a/MessageControl/MessageOutput.h
+++ b/MessageControl/MessageOutput.h
@@ -318,7 +318,7 @@ namespace Publishers {
             explicit Channel(const Core::NodeId& nodeId);
             ~Channel() override;
 
-            void Output(const Core::Messaging::Metadata& metadata, const Core::Messaging::IEvent* message);
+            void Output(const string& text);
 
         private:
             uint16_t SendData(uint8_t* dataFrame, const uint16_t maxSendSize) override;
@@ -326,7 +326,9 @@ namespace Publishers {
             uint16_t ReceiveData(uint8_t*, const uint16_t) override;
             void StateChange() override;
 
-            uint8_t _sendBuffer[Messaging::MessageUnit::TempDataBufferSize];
+            // Note: 2048 bytes is too small, casues an ASSERT from Frame - SocketPort picks it up too slowly especially at the framework startup
+            // Question: Do we want this buffer to be configurable? Same as MaxDataBufferSize? Or perhaps instead make FIFO?
+            uint8_t _sendBuffer[4096];
             uint16_t _loaded;
             Core::CriticalSection _adminLock;
         };
@@ -336,12 +338,13 @@ namespace Publishers {
         UDPOutput(const UDPOutput&) = delete;
         UDPOutput& operator=(const UDPOutput&) = delete;
 
-        explicit UDPOutput(const Core::NodeId& nodeId);
+        explicit UDPOutput(const Core::Messaging::MessageInfo::abbreviate abbreviate, const Core::NodeId& nodeId);
         ~UDPOutput() = default;
 
         void Message(const Core::Messaging::MessageInfo& metadata, const string& text);
 
     private:
+        Text _convertor;
         Channel _output;
     };
 

--- a/MessageControl/MessageOutput.h
+++ b/MessageControl/MessageOutput.h
@@ -309,6 +309,8 @@ namespace Publishers {
 
     class UDPOutput : public IPublish {
     private:
+        static constexpr uint16_t UDPBufferSize = 4 * 1024;
+
         class Channel : public Core::SocketDatagram {
         public:
             Channel() = delete;
@@ -326,9 +328,7 @@ namespace Publishers {
             uint16_t ReceiveData(uint8_t*, const uint16_t) override;
             void StateChange() override;
 
-            // Note: 2048 bytes is too small, casues an ASSERT from Frame - SocketPort picks it up too slowly especially at the framework startup
-            // Question: Do we want this buffer to be configurable? Same as MaxDataBufferSize? Or perhaps instead make FIFO?
-            uint8_t _sendBuffer[4096];
+            uint8_t _sendBuffer[UDPBufferSize];
             uint16_t _loaded;
             Core::CriticalSection _adminLock;
         };


### PR DESCRIPTION
Like we discussed on Teams with @sebaszm, there are two major changes:

1. Making sure that UDP output uses the `Convert()` as all other Publishers, since it has not been updated up to this point
2. Allowing to store more than just one message in the `_sendBuffer`, since the `Trigger()` call is asynchronous. With Thunder already running, the `SendData()` method is called on average once every 1-3 calls of the Output() method, but when the framework starts, it can take quite a while before the first buffer "flush" happens (hence 4KB size, since I was still getting an ASSERT with 2KB)