### PR TITLE
[Actions] Adding a MacOS build workflow, fixing several MacOS specific compilation errors and warnings

### DIFF
--- a/.github/workflows/Build ThunderNanoServicesRDK on MacOS.yml
+++ b/.github/workflows/Build ThunderNanoServicesRDK on MacOS.yml
@@ -3,7 +3,7 @@ name: Build ThunderNanoServicesRDK on MacOS
 on:
   workflow_dispatch:
   push:
-    branches: ["development/Actions-macOS"] # change back to master for release
+    branches: ["master"]
   pull_request:
     branches: ["master"]
 
@@ -17,4 +17,4 @@ jobs:
 
   ThunderNanoServicesRDK:
     needs: ThunderInterfaces
-    uses: WebPlatformForEmbedded/ThunderNanoServicesRDK/.github/workflows/MacOS build template.yml@development/Actions-macOS # change back to master for release
+    uses: WebPlatformForEmbedded/ThunderNanoServicesRDK/.github/workflows/MacOS build template.yml@master

--- a/.github/workflows/Build ThunderNanoServicesRDK on MacOS.yml
+++ b/.github/workflows/Build ThunderNanoServicesRDK on MacOS.yml
@@ -1,0 +1,20 @@
+name: Build ThunderNanoServicesRDK on MacOS
+
+on:
+  workflow_dispatch:
+  push:
+    branches: ["development/Actions-macOS"] # change back to master for release
+  pull_request:
+    branches: ["master"]
+
+jobs:
+  Thunder:
+    uses: rdkcentral/Thunder/.github/workflows/MacOS build template.yml@master
+
+  ThunderInterfaces:
+    needs: Thunder
+    uses: rdkcentral/ThunderInterfaces/.github/workflows/MacOS build template.yml@master
+
+  ThunderNanoServicesRDK:
+    needs: ThunderInterfaces
+    uses: WebPlatformForEmbedded/ThunderNanoServicesRDK/.github/workflows/MacOS build template.yml@development/Actions-macOS # change back to master for release

--- a/.github/workflows/MacOS build template.yml
+++ b/.github/workflows/MacOS build template.yml
@@ -1,0 +1,81 @@
+name: MacOS build template
+
+on:
+  workflow_call:
+
+jobs:
+  ThunderNanoServicesRDK:
+
+    runs-on: macos-14
+
+    strategy:
+      matrix:
+        build_type: [Debug, Release, MinSizeRel]
+
+    name: Build type - ${{matrix.build_type}}
+    steps:
+# --------- Packages & artifacts ---------
+    - name: Install necessary packages
+      run: |
+          brew update
+          brew upgrade
+          brew install ninja zlib
+          python3 -m venv venv
+          source venv/bin/activate
+          pip install jsonref
+
+    - name: Download artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: ThunderInterfaces-${{matrix.build_type}}-artifact
+        path: ${{matrix.build_type}}
+
+    - name: Unpack files
+      run: |
+        tar -xvzf ${{matrix.build_type}}/${{matrix.build_type}}.tar.gz
+        rm ${{matrix.build_type}}/${{matrix.build_type}}.tar.gz
+
+# ----- Checkout & Options regex -----
+    - name: Checkout ThunderNanoServicesRDK
+      uses: actions/checkout@v4
+      with:
+        path: ThunderNanoServicesRDK
+        repository: WebPlatformForEmbedded/ThunderNanoServicesRDK
+
+    - name: Regex ThunderNanoServicesRDK
+      if: contains(github.event.pull_request.body, '[Options:')
+      id: plugins
+      uses: AsasInnab/regex-action@v1
+      with:
+        regex_pattern: '(?<=\[Options:).*(?=\])'
+        regex_flags: 'gim'
+        search_string: ${{github.event.pull_request.body}}
+
+# ----- Build & upload artifacts -----
+    - name: Build ThunderNanoServicesRDK
+      run: |
+        source venv/bin/activate
+        cmake -G Ninja -S ThunderNanoServicesRDK -B ${{matrix.build_type}}/build/ThunderNanoServicesRDK \
+        -DCMAKE_CXX_FLAGS="-Wall -Wextra -Wpedantic -Werror -m${{matrix.architecture}}" \
+        -DCMAKE_C_FLAGS="-Wall -Wextra -Wpedantic -Werror -m${{matrix.architecture}}" \
+        -DCMAKE_INSTALL_PREFIX="${{matrix.build_type}}/install/usr" \
+        -DCMAKE_MODULE_PATH="${PWD}/${{matrix.build_type}}/install/usr/include/WPEFramework/Modules" \
+        -DPLUGIN_DEVICEIDENTIFICATION=ON \
+        -DPLUGIN_DEVICEINFO=ON \
+        -DPLUGIN_LOCATIONSYNC=ON \
+        -DPLUGIN_MESSAGECONTROL=ON \
+        -DPLUGIN_MESSENGER=ON \
+        -DPLUGIN_MONITOR=ON \
+        -DPLUGIN_OPENCDMI=ON \
+        -DPLUGIN_PERFORMANCEMETRICS=ON \
+        ${{steps.plugins.outputs.first_match}}
+        cmake --build ${{matrix.build_type}}/build/ThunderNanoServicesRDK --target install
+
+    - name: Tar files
+      run: tar -czvf ${{matrix.build_type}}.tar.gz ${{matrix.build_type}}
+
+    - name: Upload
+      uses: actions/upload-artifact@v4
+      with:
+        name: ThunderNanoServicesRDK-${{matrix.build_type}}-artifact
+        path: ${{matrix.build_type}}.tar.gz

--- a/.github/workflows/MacOS build template.yml
+++ b/.github/workflows/MacOS build template.yml
@@ -60,7 +60,7 @@ jobs:
         -DCMAKE_C_FLAGS="-Wall -Wextra -Wpedantic -Werror" \
         -DCMAKE_INSTALL_PREFIX="${{matrix.build_type}}/install/usr" \
         -DCMAKE_MODULE_PATH="${PWD}/${{matrix.build_type}}/install/usr/include/WPEFramework/Modules" \
-        -DPLUGIN_DEVICEIDENTIFICATION=ON \
+        -DPLUGIN_DEVICEIDENTIFICATION=OFF \
         -DPLUGIN_DEVICEINFO=ON \
         -DPLUGIN_LOCATIONSYNC=ON \
         -DPLUGIN_MESSAGECONTROL=ON \

--- a/.github/workflows/MacOS build template.yml
+++ b/.github/workflows/MacOS build template.yml
@@ -56,8 +56,8 @@ jobs:
       run: |
         source venv/bin/activate
         cmake -G Ninja -S ThunderNanoServicesRDK -B ${{matrix.build_type}}/build/ThunderNanoServicesRDK \
-        -DCMAKE_CXX_FLAGS="-Wall -Wextra -Wpedantic -Werror -m${{matrix.architecture}}" \
-        -DCMAKE_C_FLAGS="-Wall -Wextra -Wpedantic -Werror -m${{matrix.architecture}}" \
+        -DCMAKE_CXX_FLAGS="-Wall -Wextra -Wpedantic -Werror" \
+        -DCMAKE_C_FLAGS="-Wall -Wextra -Wpedantic -Werror" \
         -DCMAKE_INSTALL_PREFIX="${{matrix.build_type}}/install/usr" \
         -DCMAKE_MODULE_PATH="${PWD}/${{matrix.build_type}}/install/usr/include/WPEFramework/Modules" \
         -DPLUGIN_DEVICEIDENTIFICATION=ON \

--- a/MessageControl/MessageControl.h
+++ b/MessageControl/MessageControl.h
@@ -300,6 +300,9 @@ namespace Plugin {
         END_INTERFACE_MAP
 
     public:
+	using PluginHost::JSONRPC::Attach;
+	using PluginHost::JSONRPC::Detach;
+
         const string Initialize(PluginHost::IShell* service) override;
         void Deinitialize(PluginHost::IShell* service) override;
         string Information() const override;

--- a/MessageControl/MessageOutput.h
+++ b/MessageControl/MessageOutput.h
@@ -62,7 +62,7 @@ namespace Publishers {
         ~ConsoleOutput() override = default;
 
     public:
-        void Message(const Core::Messaging::MessageInfo& metadata, const string& text);
+        void Message(const Core::Messaging::MessageInfo& metadata, const string& text) override;
 
     private:
         Text _convertor;
@@ -81,7 +81,7 @@ namespace Publishers {
         ~SyslogOutput() override = default;
 
     public:
-        void Message(const Core::Messaging::MessageInfo& metadata, const string& text);
+        void Message(const Core::Messaging::MessageInfo& metadata, const string& text) override;
 
     private:
         Text _convertor;
@@ -111,7 +111,7 @@ namespace Publishers {
         }
 
     public:
-        void Message(const Core::Messaging::MessageInfo& metadata, const string& text);
+        void Message(const Core::Messaging::MessageInfo& metadata, const string& text) override;
 
     private:
         Text _convertor;
@@ -377,7 +377,7 @@ namespace Publishers {
         }
 
         void UpdateChannel();
-        void Message(const Core::Messaging::MessageInfo& metadata, const string& text);
+        void Message(const Core::Messaging::MessageInfo& metadata, const string& text) override;
 
     private:
         Text _convertor;

--- a/Monitor/Monitor.h
+++ b/Monitor/Monitor.h
@@ -490,8 +490,8 @@ namespace Plugin {
                     }
                 }
 
-                MonitorObject(MonitorObject&) = delete;
-                MonitorObject& operator=(MonitorObject&) = delete;
+                MonitorObject(MonitorObject&) = default;
+                MonitorObject& operator=(MonitorObject&);
                 MonitorObject(MonitorObject&&) = delete;
                 MonitorObject& operator=(MonitorObject&&) = delete;
 

--- a/Monitor/Monitor.h
+++ b/Monitor/Monitor.h
@@ -490,8 +490,8 @@ namespace Plugin {
                     }
                 }
 
-                MonitorObject(MonitorObject&) = default;
-                MonitorObject& operator=(MonitorObject&);
+                MonitorObject(MonitorObject&) = delete;
+                MonitorObject& operator=(MonitorObject&) = delete;
                 MonitorObject(MonitorObject&&) = delete;
                 MonitorObject& operator=(MonitorObject&&) = delete;
 

--- a/Monitor/Monitor.h
+++ b/Monitor/Monitor.h
@@ -490,8 +490,8 @@ namespace Plugin {
                     }
                 }
 
-                MonitorObject(MonitorObject&) = delete;
-                MonitorObject& operator=(MonitorObject&) = delete;
+                MonitorObject(const MonitorObject&) = delete;
+                MonitorObject& operator=(const MonitorObject&) = delete;
                 MonitorObject(MonitorObject&&) = delete;
                 MonitorObject& operator=(MonitorObject&&) = delete;
 

--- a/Monitor/Monitor.h
+++ b/Monitor/Monitor.h
@@ -440,7 +440,6 @@ namespace Plugin {
             class MonitorObject {
             public:
                 MonitorObject() = delete;
-                MonitorObject& operator=(const MonitorObject&) = delete;
 
                 enum evaluation {
                     SUCCESFULL = 0x00,

--- a/OpenCDMi/CMakeLists.txt
+++ b/OpenCDMi/CMakeLists.txt
@@ -53,7 +53,9 @@ add_library(${MODULE_NAME} SHARED
         FrameworkRPC.cpp
         Module.cpp)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-gnu-unique")
+if (CMAKE_COMPILER_IS_GNUCXX)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-gnu-unique")
+endif()
 
 set_target_properties(${MODULE_NAME} PROPERTIES
         CXX_STANDARD 11

--- a/OpenCDMi/CMakeLists.txt
+++ b/OpenCDMi/CMakeLists.txt
@@ -53,7 +53,7 @@ add_library(${MODULE_NAME} SHARED
         FrameworkRPC.cpp
         Module.cpp)
 
-if (CMAKE_COMPILER_IS_GNUCXX)
+if(CMAKE_COMPILER_IS_GNUCXX)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-gnu-unique")
 endif()
 

--- a/OpenCDMi/FrameworkRPC.cpp
+++ b/OpenCDMi/FrameworkRPC.cpp
@@ -375,9 +375,9 @@ namespace Plugin {
 
                 private:
                     CDMi::IMediaKeySession* _mediaKeys;
-                    CDMi::IMediaKeySessionExt* _mediaKeysExt;
-                    uint8_t* _sessionKey;
-                    uint32_t _sessionKeyLength;
+                    VARIABLE_IS_NOT_USED CDMi::IMediaKeySessionExt* _mediaKeysExt;
+                    VARIABLE_IS_NOT_USED uint8_t* _sessionKey;
+                    VARIABLE_IS_NOT_USED uint32_t _sessionKeyLength;
                 };
 
                 // IMediaKeys defines the MediaKeys interface.
@@ -748,7 +748,7 @@ POP_WARNING()
             private:
                 AccessorOCDM& _parent;
                 mutable Core::CriticalSection _adminLock;
-                mutable uint32_t _refCount;
+                VARIABLE_IS_NOT_USED mutable uint32_t _refCount;
                 std::string _keySystem;
                 std::string _sessionId;
                 CDMi::IMediaKeySession* _mediaKeySession;
@@ -954,7 +954,7 @@ POP_WARNING()
                 const std::string& keySystem,
                 unsigned char Ids[],
                 uint16_t idsLength,
-                uint32_t& count)
+                uint32_t& count) override
             {
                 CDMi::IMediaKeysExt* systemExt = dynamic_cast<CDMi::IMediaKeysExt*>(_parent.KeySystem(keySystem));
                 if (systemExt) {
@@ -982,7 +982,7 @@ POP_WARNING()
                 const unsigned char sessionID[],
                 uint16_t sessionIDLength,
                 const unsigned char serverResponse[],
-                uint16_t serverResponseLength)
+                uint16_t serverResponseLength) override
             {
                 CDMi::IMediaKeysExt* systemExt = dynamic_cast<CDMi::IMediaKeysExt*>(_parent.KeySystem(keySystem));
                 if (systemExt) {
@@ -1418,21 +1418,21 @@ POP_WARNING()
             }
         }
 
-        virtual uint32_t Reset()
+        virtual uint32_t Reset() override
         {
             return (Core::ERROR_NONE);
         }
-        virtual RPC::IStringIterator* Systems() const
+        virtual RPC::IStringIterator* Systems() const override
         {
             return (Core::ServiceType<RPC::StringIterator>::Create<RPC::IStringIterator>(_keySystems));
         }
-        virtual RPC::IStringIterator* Designators(const string& keySystem) const
+        virtual RPC::IStringIterator* Designators(const string& keySystem) const override
         {
             std::list<string> designators;
             LoadDesignators(keySystem, designators);
             return (Core::ServiceType<RPC::StringIterator>::Create<RPC::IStringIterator>(designators));
         }
-        virtual RPC::IStringIterator* Sessions(const string& keySystem) const
+        virtual RPC::IStringIterator* Sessions(const string& keySystem) const override
         {
             std::list<string> sessions;
             LoadSessions(keySystem, sessions);

--- a/OpenCDMi/Protobuf.h
+++ b/OpenCDMi/Protobuf.h
@@ -463,7 +463,7 @@ namespace Protobuf {
             }
             return (result);
         }
-        WireType Type() const {
+        WireType Type() const override {
             return (WireType::LENGTH_DELIMITED);
         }
 

--- a/PerformanceMetrics/PerformanceMetrics.h
+++ b/PerformanceMetrics/PerformanceMetrics.h
@@ -664,17 +664,17 @@ POP_WARNING()
         // If there is an error, return a string describing the issue why the initialisation failed.
         // The Service object is *NOT* reference counted, lifetime ends if the plugin is deactivated.
         // The lifetime of the Service object is guaranteed till the deinitialize method is called.
-        virtual const string Initialize(PluginHost::IShell* service);
+        virtual const string Initialize(PluginHost::IShell* service) override;
 
         // The plugin is unloaded from Thunder. This is call allows the module to notify clients
         // or to persist information if needed. After this call the plugin will unlink from the service path
         // and be deactivated. The Service object is the same as passed in during the Initialize.
         // After theis call, the lifetime of the Service object ends.
-        virtual void Deinitialize(PluginHost::IShell* service);
+        virtual void Deinitialize(PluginHost::IShell* service) override;
 
         // Returns an interface to a JSON struct that can be used to return specific metadata information with respect
         // to this plugin. This Metadata can be used by the MetData plugin to publish this information to the ouside world.
-        virtual string Information() const;
+        virtual string Information() const override;
 
     private:
 

--- a/PerformanceMetrics/TraceOutput.cpp
+++ b/PerformanceMetrics/TraceOutput.cpp
@@ -97,7 +97,7 @@ public:
         }
     }
 
-    void Activated() 
+    void Activated() override
     {
         if( _memory != nullptr ) {
             TRACE(Trace::Metric, (_T("Plugin %s activated, RSS: %llu"), _callsign.c_str(), _memory->Resident()));

--- a/PerformanceMetrics/TraceOutput.cpp
+++ b/PerformanceMetrics/TraceOutput.cpp
@@ -226,7 +226,6 @@ std::unique_ptr<PerformanceMetrics::IBrowserMetricsLogger> PerformanceMetrics::L
 
 template std::unique_ptr<PerformanceMetrics::IBasicMetricsLogger> PerformanceMetrics::LoggerFactory<PerformanceMetrics::IBasicMetricsLogger>();                
 template std::unique_ptr<PerformanceMetrics::IStateMetricsLogger> PerformanceMetrics::LoggerFactory<PerformanceMetrics::IStateMetricsLogger>();                
-template std::unique_ptr<PerformanceMetrics::IBrowserMetricsLogger> PerformanceMetrics::LoggerFactory<PerformanceMetrics::IBrowserMetricsLogger>();                
 
 }
 }

--- a/PerformanceMetrics/TraceOutput.cpp
+++ b/PerformanceMetrics/TraceOutput.cpp
@@ -158,7 +158,7 @@ public:
         }
     }
 
-    void Activated() 
+    void Activated() override
     {
     }
 


### PR DESCRIPTION
@sebaszm are the unused member variables in `OpenCDMi/FrameworkRPC.cpp` necessary for anything, or can we get rid of them completely?