### PR TITLE
[Actions] Make sure all MacOS job names are unique

### DIFF
--- a/.github/workflows/Build ThunderNanoServicesRDK on MacOS.yml
+++ b/.github/workflows/Build ThunderNanoServicesRDK on MacOS.yml
@@ -8,13 +8,13 @@ on:
     branches: ["master"]
 
 jobs:
-  Thunder:
+  Thunder_MacOS:
     uses: rdkcentral/Thunder/.github/workflows/MacOS build template.yml@master
 
-  ThunderInterfaces:
-    needs: Thunder
+  ThunderInterfaces_MacOS:
+    needs: Thunder_MacOS
     uses: rdkcentral/ThunderInterfaces/.github/workflows/MacOS build template.yml@master
 
-  ThunderNanoServicesRDK:
-    needs: ThunderInterfaces
+  ThunderNanoServicesRDK_MacOS:
+    needs: ThunderInterfaces_MacOS
     uses: WebPlatformForEmbedded/ThunderNanoServicesRDK/.github/workflows/MacOS build template.yml@master


### PR DESCRIPTION
Otherwise it clashes with the Linux required checks, even despite the workflow name being different