### PR TITLE
[OpenCDMi] Remove all unnecessary member variables to save some memory

### DIFF
--- a/OpenCDMi/FrameworkRPC.cpp
+++ b/OpenCDMi/FrameworkRPC.cpp
@@ -286,9 +286,6 @@ namespace Plugin {
                         : Exchange::DataExchange(name, defaultSize)
                         , Core::Thread(Core::Thread::DefaultStackSize(), _T("DRMSessionThread"))
                         , _mediaKeys(mediaKeys)
-                        , _mediaKeysExt(dynamic_cast<CDMi::IMediaKeySessionExt*>(mediaKeys))
-                        , _sessionKey(nullptr)
-                        , _sessionKeyLength(0)
                     {
                         Core::Thread::Run();
                         TRACE(Trace::Information, (_T("Constructing buffer server side: %p - %s"), this, name.c_str()));
@@ -375,11 +372,6 @@ namespace Plugin {
 
                 private:
                     CDMi::IMediaKeySession* _mediaKeys;
-PUSH_WARNING(DISABLE_WARNING_UNUSED_VARIABLES)
-                    CDMi::IMediaKeySessionExt* _mediaKeysExt;
-                    uint8_t* _sessionKey;
-                    uint32_t _sessionKeyLength;
-POP_WARNING()
                 };
 
                 // IMediaKeys defines the MediaKeys interface.
@@ -497,7 +489,6 @@ PUSH_WARNING(DISABLE_WARNING_THIS_IN_MEMBER_INITIALIZER_LIST)
                     Exchange::ISession::ICallback* callback,
                     const CommonEncryptionData* sessionData)
                     : _parent(*parent)
-                    , _refCount(1)
                     , _keySystem(keySystem)
                     , _sessionId(mediaKeySession->GetSessionId())
                     , _mediaKeySession(mediaKeySession)
@@ -522,7 +513,6 @@ PUSH_WARNING(DISABLE_WARNING_THIS_IN_MEMBER_INITIALIZER_LIST)
                     Exchange::ISession::ICallback* callback,
                     const CommonEncryptionData* sessionData)
                     : _parent(*parent)
-                    , _refCount(1)
                     , _keySystem(keySystem)
                     , _sessionId("")
                     , _mediaKeySession(dynamic_cast<CDMi::IMediaKeySession*>(mediaKeySession))
@@ -750,9 +740,6 @@ POP_WARNING()
             private:
                 AccessorOCDM& _parent;
                 mutable Core::CriticalSection _adminLock;
-PUSH_WARNING(DISABLE_WARNING_UNUSED_VARIABLES)
-                mutable uint32_t _refCount;
-POP_WARNING()
                 std::string _keySystem;
                 std::string _sessionId;
                 CDMi::IMediaKeySession* _mediaKeySession;

--- a/OpenCDMi/FrameworkRPC.cpp
+++ b/OpenCDMi/FrameworkRPC.cpp
@@ -372,6 +372,7 @@ namespace Plugin {
 
                         return (Core::infinite);
                     }
+
                 private:
                     CDMi::IMediaKeySession* _mediaKeys;
 PUSH_WARNING(DISABLE_WARNING_UNUSED_VARIABLES)

--- a/OpenCDMi/FrameworkRPC.cpp
+++ b/OpenCDMi/FrameworkRPC.cpp
@@ -372,12 +372,13 @@ namespace Plugin {
 
                         return (Core::infinite);
                     }
-
                 private:
                     CDMi::IMediaKeySession* _mediaKeys;
-                    VARIABLE_IS_NOT_USED CDMi::IMediaKeySessionExt* _mediaKeysExt;
-                    VARIABLE_IS_NOT_USED uint8_t* _sessionKey;
-                    VARIABLE_IS_NOT_USED uint32_t _sessionKeyLength;
+PUSH_WARNING(DISABLE_WARNING_UNUSED_VARIABLES)
+                    CDMi::IMediaKeySessionExt* _mediaKeysExt;
+                    uint8_t* _sessionKey;
+                    uint32_t _sessionKeyLength;
+POP_WARNING()
                 };
 
                 // IMediaKeys defines the MediaKeys interface.
@@ -748,7 +749,9 @@ POP_WARNING()
             private:
                 AccessorOCDM& _parent;
                 mutable Core::CriticalSection _adminLock;
-                VARIABLE_IS_NOT_USED mutable uint32_t _refCount;
+PUSH_WARNING(DISABLE_WARNING_UNUSED_VARIABLES)
+                mutable uint32_t _refCount;
+POP_WARNING()
                 std::string _keySystem;
                 std::string _sessionId;
                 CDMi::IMediaKeySession* _mediaKeySession;


### PR DESCRIPTION
@HaseenaSainul discovered that the `VARIABLE_IS_NOT_USED` leads to the build error with buildroot:
```
FrameworkRPC.cpp:383:69: error: ‘unused’ attribute ignored [-Werror=attributes]
  383 |                     VARIABLE_IS_NOT_USED CDMi::IMediaKeySessionExt* _mediaKeysExt;
      |                                                                     ^~~~~~~~~~~~~
FrameworkRPC.cpp:384:51: error: ‘unused’ attribute ignored [-Werror=attributes]
  384 |                     VARIABLE_IS_NOT_USED uint8_t* _sessionKey;
      |                                                   ^~~~~~~~~~~
FrameworkRPC.cpp:385:51: error: ‘unused’ attribute ignored [-Werror=attributes]
  385 |                     VARIABLE_IS_NOT_USED uint32_t _sessionKeyLength;
      |                                                   ^~~~~~~~~~~~~~~~~
FrameworkRPC.cpp:756:55: error: ‘unused’ attribute ignored [-Werror=attributes]
  756 |                 VARIABLE_IS_NOT_USED mutable uint32_t _refCount;
```
So let's just removed the unused member variables and save some memory