### PR TITLE
[SecAgent] fix test mode token

### DIFF
--- a/SecurityAgent/SecurityAgent.h
+++ b/SecurityAgent/SecurityAgent.h
@@ -223,7 +223,7 @@ namespace Plugin {
         Core::ProxyType<DirectoryCallback> _dacDirCallback;
 
 #ifdef SECURITY_TESTING_MODE
-        static constexpr const TCHAR* TestTokenContent = _T(R"--({ "url": "https://test.url.com", "user":"Test" })--");
+        static constexpr TCHAR TestTokenContent[] = _T(R"--({ "url": "https://test.url.com", "user":"Test" })--");
 #endif // DEBUG
     };
 


### PR DESCRIPTION
Fix testmode token as a previous change broke it from what is was (no clue why it was changed).
As we take the sizeof later on the result, sizeof(char*) gives a completely different answer (incorrect of course) than sizeof(char[])