### PR TITLE
[Packager] Update after changes to the interface

### DIFF
--- a/Packager/Packager.cpp
+++ b/Packager/Packager.cpp
@@ -56,13 +56,6 @@ namespace {
             result = _T("Couldn't create PACKAGER instance ");
 
         } else {
-            Register<Params, void>(kInstallMethodName, [this](const Params& params) -> uint32_t {
-                return this->_implementation->Install(params.Package.Value(), params.Version.Value(),
-                                                                 params.Architecture.Value());
-            });
-            Register<void, void>(kSynchronizeMethodName, [this]() -> uint32_t {
-                return this->_implementation->SynchronizeRepository();
-            });
             if (_implementation->Configure(_service) != Core::ERROR_NONE) {
                 result = _T("Couldn't initialize PACKAGER instance");
             }
@@ -79,8 +72,6 @@ namespace {
             _service->Unregister(&_notification);
 
             if (_implementation != nullptr) {
-                Unregister(kInstallMethodName);
-                Unregister(kSynchronizeMethodName);
 
                 RPC::IRemoteConnection* connection(_service->RemoteConnection(_connectionId));
 

--- a/Packager/Packager.h
+++ b/Packager/Packager.h
@@ -24,10 +24,6 @@
 
 namespace Thunder {
 namespace Plugin {
-namespace {
-    constexpr auto* kInstallMethodName = _T("install");
-    constexpr auto* kSynchronizeMethodName = _T("synchronize");
-}
 
     class Packager : public PluginHost::IPlugin,
                      public PluginHost::IWeb,

--- a/Packager/PackagerImplementation.cpp
+++ b/Packager/PackagerImplementation.cpp
@@ -154,19 +154,19 @@ namespace Plugin {
         _adminLock.Unlock();
     }
 
-    uint32_t PackagerImplementation::Install(const string& name, const string& version, const string& arch)
+    Core::hresult PackagerImplementation::Install(const string& name, const string& version, const string& arch)
     {
         return DoWork(&name, &version, &arch);
     }
 
-    uint32_t PackagerImplementation::SynchronizeRepository()
+    Core::hresult PackagerImplementation::SynchronizeRepository()
     {
         return DoWork(nullptr, nullptr, nullptr);
     }
 
-    uint32_t PackagerImplementation::DoWork(const string* name, const string* version, const string* arch)
+    Core::hresult PackagerImplementation::DoWork(const string* name, const string* version, const string* arch)
     {
-        uint32_t result = Core::ERROR_INPROGRESS;
+        Core::hresult result = Core::ERROR_INPROGRESS;
 
         _adminLock.Lock();
         if (_inProgress.Install == nullptr && _isSyncing == false) {

--- a/Packager/PackagerImplementation.h
+++ b/Packager/PackagerImplementation.h
@@ -128,9 +128,13 @@ namespace Plugin {
             , _isUpgrade(false)
             , _isSyncing(false)
         {
+            Exchange::JPackager::Register(*this, this);
         }
 
-        ~PackagerImplementation() override;
+        ~PackagerImplementation() override
+        {
+            Exchange::JPackager::Unregister(*this);
+        }
 
         BEGIN_INTERFACE_MAP(PackagerImplementation)
             INTERFACE_ENTRY(Exchange::IPackager)
@@ -140,8 +144,8 @@ namespace Plugin {
         void Register(Exchange::IPackager::INotification* observer) override;
         void Unregister(const Exchange::IPackager::INotification* observer) override;
         uint32_t Configure(PluginHost::IShell* service) override;
-        uint32_t Install(const string& name, const string& version, const string& arch) override;
-        uint32_t SynchronizeRepository() override;
+        Core::hresult Install(const string& name, const string& version, const string& arch) override;
+        Core::hresult SynchronizeRepository() override;
 
     private:
         class PackageInfo : public Exchange::IPackager::IPackageInfo {

--- a/Packager/PackagerPlugin.json
+++ b/Packager/PackagerPlugin.json
@@ -10,7 +10,7 @@
     ],
     "version": "1.0"
   },
-  "interface": {
-    "$ref": "{interfacedir}/Packager.json"
-  }
+  "interface": [
+    { "$ref": "{cppinterfacedir}/IPackager.h" }
+  ]
 }

--- a/Packager/doc/PackagerPlugin.md
+++ b/Packager/doc/PackagerPlugin.md
@@ -105,9 +105,9 @@ Install a package given by a name, an URL or a file path.
 | Name | Type | M/O | Description |
 | :-------- | :-------- | :-------- | :-------- |
 | params | object | mandatory | *...* |
-| params.name | string | mandatory | *...* |
-| params.version | string | mandatory | *...* |
-| params.arch | string | mandatory | *...* |
+| params.name | string | mandatory | Name, URL or file path of the package to install |
+| params.version | string | mandatory | Version of the package to install |
+| params.arch | string | mandatory | Architecture of the package to install |
 
 ### Result
 
@@ -132,9 +132,9 @@ Install a package given by a name, an URL or a file path.
   "id": 42,
   "method": "Packager.1.install",
   "params": {
-    "name": "...",
-    "version": "...",
-    "arch": "..."
+    "name": "thunder-plugin-netflix",
+    "version": "1.0",
+    "arch": "arm"
   }
 }
 ```

--- a/Packager/doc/PackagerPlugin.md
+++ b/Packager/doc/PackagerPlugin.md
@@ -13,6 +13,7 @@ Packager plugin for Thunder framework.
 - [Introduction](#head.Introduction)
 - [Description](#head.Description)
 - [Configuration](#head.Configuration)
+- [Interfaces](#head.Interfaces)
 - [Methods](#head.Methods)
 
 <a name="head.Introduction"></a>
@@ -21,12 +22,12 @@ Packager plugin for Thunder framework.
 <a name="head.Scope"></a>
 ## Scope
 
-This document describes purpose and functionality of the Packager plugin. It includes detailed specification of its configuration and methods provided.
+This document describes purpose and functionality of the Packager plugin. It includes detailed specification about its configuration and methods provided.
 
 <a name="head.Case_Sensitivity"></a>
 ## Case Sensitivity
 
-All identifiers on the interface described in this document are case-sensitive. Thus, unless stated otherwise, all keywords, entities, properties, relations and actions should be treated as such.
+All identifiers of the interfaces described in this document are case-sensitive. Thus, unless stated otherwise, all keywords, entities, properties, relations and actions should be treated as such.
 
 <a name="head.Acronyms,_Abbreviations_and_Terms"></a>
 ## Acronyms, Abbreviations and Terms
@@ -68,12 +69,19 @@ The plugin is designed to be loaded and executed within the Thunder framework. F
 
 The table below lists configuration options of the plugin.
 
-| Name | Type | Description |
-| :-------- | :-------- | :-------- |
-| callsign | string | Plugin instance name (default: *Packager*) |
-| classname | string | Class name: *Packager* |
-| locator | string | Library name: *libThunderPackager.so* |
-| startmode | string | Determines if the plugin shall be started automatically along with the framework |
+| Name | Type | M/O | Description |
+| :-------- | :-------- | :-------- | :-------- |
+| callsign | string | mandatory | Plugin instance name (default: *Packager*) |
+| classname | string | mandatory | Class name: *Packager* |
+| locator | string | mandatory | Library name: *libThunderPackager.so* |
+| startmode | string | mandatory | Determines in which state the plugin should be moved to at startup of the framework |
+
+<a name="head.Interfaces"></a>
+# Interfaces
+
+This plugin implements the following interfaces:
+
+- IPackager ([IPackager.h](https://github.com/rdkcentral/ThunderInterfaces/blob/master/interfaces/IPackager.h)) (version 1.0.0) (compliant format)
 
 <a name="head.Methods"></a>
 # Methods
@@ -84,34 +92,35 @@ Packager interface methods:
 
 | Method | Description |
 | :-------- | :-------- |
-| [install](#method.install) | Installs a package given by a name, an URL or a file path |
-| [synchronize](#method.synchronize) | Synchronizes repository manifest with a repository |
+| [install](#method.install) | Install a package given by a name, an URL or a file path |
+| [synchronizerepository](#method.synchronizerepository) / [::](#method.synchronizerepository) | Synchronize repository manifest with a repository |
 
 <a name="method.install"></a>
-## *install <sup>method</sup>*
+## *install [<sup>method</sup>](#head.Methods)*
 
-Installs a package given by a name, an URL or a file path.
+Install a package given by a name, an URL or a file path.
 
 ### Parameters
 
-| Name | Type | Description |
-| :-------- | :-------- | :-------- |
-| params | object |  |
-| params.package | string | A name, an URL or a file path of the package to install |
-| params?.version | string | <sup>*(optional)*</sup> Version of the package to install |
-| params?.architecture | string | <sup>*(optional)*</sup> Architecture of the package to install |
+| Name | Type | M/O | Description |
+| :-------- | :-------- | :-------- | :-------- |
+| params | object | mandatory | *...* |
+| params.name | string | mandatory | *...* |
+| params.version | string | mandatory | *...* |
+| params.arch | string | mandatory | *...* |
 
 ### Result
 
-| Name | Type | Description |
-| :-------- | :-------- | :-------- |
-| result | null | Always null |
+| Name | Type | M/O | Description |
+| :-------- | :-------- | :-------- | :-------- |
+| result | null | mandatory | Always null |
 
 ### Errors
 
-| Code | Message | Description |
-| :-------- | :-------- | :-------- |
-| 12 | ```ERROR_INPROGRESS``` | Returned when the function is called while other installation/synchronization is already in progress. |
+| Message | Description |
+| :-------- | :-------- |
+| ```ERROR_INPROGRESS``` | Other installation/synchronization is already in progress |
+| ```ERROR_GENERAL``` | Opkg package manager not initialized successfully |
 
 ### Example
 
@@ -119,29 +128,33 @@ Installs a package given by a name, an URL or a file path.
 
 ```json
 {
-    "jsonrpc": "2.0",
-    "id": 1234567890,
-    "method": "Packager.1.install",
-    "params": {
-        "package": "thunder-plugin-netflix",
-        "version": "1.0",
-        "architecture": "arm"
-    }
+  "jsonrpc": "2.0",
+  "id": 42,
+  "method": "Packager.1.install",
+  "params": {
+    "name": "...",
+    "version": "...",
+    "arch": "..."
+  }
 }
 ```
+
 #### Response
 
 ```json
 {
-    "jsonrpc": "2.0",
-    "id": 1234567890,
-    "result": null
+  "jsonrpc": "2.0",
+  "id": 42,
+  "result": null
 }
 ```
-<a name="method.synchronize"></a>
-## *synchronize <sup>method</sup>*
 
-Synchronizes repository manifest with a repository.
+<a name="method.synchronizerepository"></a>
+## *synchronizerepository [<sup>method</sup>](#head.Methods)*
+
+Synchronize repository manifest with a repository.
+
+> ``::`` is an alternative name for this method.
 
 ### Parameters
 
@@ -149,15 +162,16 @@ This method takes no parameters.
 
 ### Result
 
-| Name | Type | Description |
-| :-------- | :-------- | :-------- |
-| result | null | Always null |
+| Name | Type | M/O | Description |
+| :-------- | :-------- | :-------- | :-------- |
+| result | null | mandatory | Always null |
 
 ### Errors
 
-| Code | Message | Description |
-| :-------- | :-------- | :-------- |
-| 12 | ```ERROR_INPROGRESS``` | Returned when the function is called while other installation/synchronization is already in progress. |
+| Message | Description |
+| :-------- | :-------- |
+| ```ERROR_INPROGRESS``` | Other installation/synchronization is already in progress |
+| ```ERROR_GENERAL``` | Opkg package manager not initialized successfully |
 
 ### Example
 
@@ -165,17 +179,19 @@ This method takes no parameters.
 
 ```json
 {
-    "jsonrpc": "2.0",
-    "id": 1234567890,
-    "method": "Packager.1.synchronize"
+  "jsonrpc": "2.0",
+  "id": 42,
+  "method": "Packager.1.synchronizerepository"
 }
 ```
+
 #### Response
 
 ```json
 {
-    "jsonrpc": "2.0",
-    "id": 1234567890,
-    "result": null
+  "jsonrpc": "2.0",
+  "id": 42,
+  "result": null
 }
 ```
+


### PR DESCRIPTION
First, we have to merge [this](https://github.com/rdkcentral/ThunderInterfaces/pull/412) PR with changes to the interface

Packager is not building in Lithosphere by default, and trying to build it leads to a CMake error:
```
CMake Error in Packager/CMakeLists.txt:
  Imported target "LibOPKG::LibOPKG" includes non-existent path

    "/home/veith/Lithosphere/raspberrypi3_wpe/host/arm-buildroot-linux-gnueabihf/sysroot/usr/include/libopkg"

  in its INTERFACE_INCLUDE_DIRECTORIES.  Possible reasons include:

  * The path was deleted, renamed, or moved to another location.

  * An install or uninstall procedure did not complete successfully.

  * The installation package was faulty and references files it does not
  provide.
```
After manually moving `libopkg` to this location, as it was installed in `usr/lib` instead of `usr/include`, we get more include compile error:
```
/home/veith/Lithosphere/raspberrypi3_wpe/build/thunder-rdkservices-custom/Packager/PackagerImplementation.cpp:25:10: fatal error: opkg.h: No such file or directory
   25 | #include <opkg.h>
```

So for now, I cannot test the changes, but as soon as it is resolved - I'll make sure to test them.