### PR TITLE
[Actions] Build Packager on Linux with its dependencies (32- and 64-bit)

### DIFF
--- a/.github/workflows/Build ThunderNanoServicesRDK on Linux.yml
+++ b/.github/workflows/Build ThunderNanoServicesRDK on Linux.yml
@@ -17,4 +17,4 @@ jobs:
 
   ThunderNanoServicesRDK:
     needs: ThunderInterfaces
-    uses: WebPlatformForEmbedded/ThunderNanoServicesRDK/.github/workflows/Linux build template.yml@master
+    uses: WebPlatformForEmbedded/ThunderNanoServicesRDK/.github/workflows/Linux build template.yml@development/packager-opkg-actions

--- a/.github/workflows/Build ThunderNanoServicesRDK on Linux.yml
+++ b/.github/workflows/Build ThunderNanoServicesRDK on Linux.yml
@@ -17,4 +17,4 @@ jobs:
 
   ThunderNanoServicesRDK:
     needs: ThunderInterfaces
-    uses: WebPlatformForEmbedded/ThunderNanoServicesRDK/.github/workflows/Linux build template.yml@development/packager-opkg-actions
+    uses: WebPlatformForEmbedded/ThunderNanoServicesRDK/.github/workflows/Linux build template.yml@master

--- a/.github/workflows/Linux build template.yml
+++ b/.github/workflows/Linux build template.yml
@@ -7,6 +7,9 @@ jobs:
   ThunderNanoServicesRDK:
 
     runs-on: ubuntu-24.04
+    
+    env:
+      PKG_CONFIG_PATH: "/usr/local/include/libopkg:$PKG_CONFIG_PATH"
 
     strategy:
       matrix:
@@ -75,13 +78,13 @@ jobs:
         make
         sudo make install
 
-    - name: Check PKG_CONFIG_PATH
+    - name: Debug pkg-config Paths
       run: |
         echo "PKG_CONFIG_PATH: $PKG_CONFIG_PATH"
-
-    - name: Check pkg-config Default Paths
-      run: |
+        echo "Default pkg-config path:"
         pkg-config --variable=pc_path pkg-config
+        echo "Attempting to locate libopkg:"
+        pkg-config --cflags libopkg || echo "libopkg not found"
 
     - name: Build ThunderNanoServicesRDK
       run: |

--- a/.github/workflows/Linux build template.yml
+++ b/.github/workflows/Linux build template.yml
@@ -82,10 +82,23 @@ jobs:
         pkg-config --variable=pc_path pkg-config
         echo "Attempting to locate libopkg:"
         pkg-config --cflags libopkg || echo "libopkg not found"
+        pkg-config --modversion libopkg
+        pkg-config --cflags libopkg
+        pkg-config --libs libopkg
+    
+    - name: Verify libopkg include directory
+      run: |
+        if [ -d /usr/local/include/libopkg ]; then
+          echo "Directory exists."
+        else
+          echo "Directory /usr/local/include/libopkg does NOT exist."
+          ls -la /usr/local/include || true
+        fi
 
     - name: Build ThunderNanoServicesRDK
       run: |
         source venv/bin/activate
+        export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig:$PKG_CONFIG_PATH
         cmake -G Ninja -S ThunderNanoServicesRDK -B ${{matrix.build_type}}/build/ThunderNanoServicesRDK \
         -DCMAKE_CXX_FLAGS="-Wall -Wextra -Wpedantic -Werror -m${{matrix.architecture}}" \
         -DCMAKE_C_FLAGS="-Wall -Wextra -Wpedantic -Werror -m${{matrix.architecture}}" \

--- a/.github/workflows/Linux build template.yml
+++ b/.github/workflows/Linux build template.yml
@@ -77,7 +77,7 @@ jobs:
 
     - name: Check PKG_CONFIG_PATH
       run: |
-        echo "PKG_CONFIG_PATH: ${{PKG_CONFIG_PATH}}"
+        echo "PKG_CONFIG_PATH: $PKG_CONFIG_PATH"
 
     - name: Check pkg-config Default Paths
       run: |

--- a/.github/workflows/Linux build template.yml
+++ b/.github/workflows/Linux build template.yml
@@ -75,6 +75,14 @@ jobs:
         make
         sudo make install
 
+    - name: Check PKG_CONFIG_PATH
+      run: |
+        echo "PKG_CONFIG_PATH: ${{PKG_CONFIG_PATH}}"
+
+    - name: Check pkg-config Default Paths
+      run: |
+        pkg-config --variable=pc_path pkg-config
+
     - name: Build ThunderNanoServicesRDK
       run: |
         source venv/bin/activate

--- a/.github/workflows/Linux build template.yml
+++ b/.github/workflows/Linux build template.yml
@@ -71,7 +71,7 @@ jobs:
       run: |
         cd opkg
         ./autogen.sh || true
-        ./configure --prefix=/usr/local --includedir=/usr/local/include/libopkg
+        ./configure --prefix=/usr/local
         make
         sudo make install
 
@@ -92,17 +92,6 @@ jobs:
         ls -la /usr/local/include
         echo "ls -la /usr/local/lib:"
         ls -la /usr/local/lib
-        echo "ls -la /usr/local/include/libopkg:"
-        ls -la /usr/local/include/libopkg
-    
-    - name: Verify libopkg include directory
-      run: |
-        if [ -d /usr/local/include/libopkg ]; then
-          echo "Directory exists."
-        else
-          echo "Directory /usr/local/include/libopkg does NOT exist."
-          ls -la /usr/local/include || true
-        fi
 
     - name: Build ThunderNanoServicesRDK
       run: |

--- a/.github/workflows/Linux build template.yml
+++ b/.github/workflows/Linux build template.yml
@@ -28,7 +28,7 @@ jobs:
           echo "deb http://archive.ubuntu.com/ubuntu/ jammy-updates main universe restricted multiverse" | sudo tee -a /etc/apt/sources.list
           sudo dpkg --add-architecture i386
           sudo apt-get update
-          sudo apt install python3-pip build-essential cmake ninja-build libusb-1.0-0-dev autoconf automake libtool libtool-bin pkg-config libarchive-dev libcurl4-openssl-dev libgpgme-dev ${{matrix.architecture == '32' && 'zlib1g-dev:i386 libssl-dev:i386 gcc-13-multilib g++-13-multilib' || 'zlib1g-dev libssl-dev'}}
+          sudo apt install python3-pip build-essential cmake ninja-build libusb-1.0-0-dev autoconf automake libtool libtool-bin pkg-config ${{matrix.architecture == '32' && 'zlib1g-dev:i386 libssl-dev:i386 gcc-13-multilib g++-13-multilib libarchive-dev:i386 libcurl4-openssl-dev:i386 libgpgme-dev:i386 libgpg-error-dev:i386' || 'zlib1g-dev libssl-dev libarchive-dev libcurl4-openssl-dev libgpgme-dev libgpg-error-dev'}}
           python3 -m venv venv
           source venv/bin/activate
           pip install jsonref

--- a/.github/workflows/Linux build template.yml
+++ b/.github/workflows/Linux build template.yml
@@ -60,7 +60,7 @@ jobs:
         regex_flags: 'gim'
         search_string: ${{github.event.pull_request.body}}
 
-    - name: Checkout OPKG
+    - name: Checkout libopkg
       uses: actions/checkout@v4
       with:
         path: opkg
@@ -75,30 +75,10 @@ jobs:
         make
         sudo make install
 
-    - name: Debug pkg-config Paths
-      run: |
-        echo "PKG_CONFIG_PATH: $PKG_CONFIG_PATH"
-        echo "Default pkg-config path:"
-        pkg-config --variable=pc_path pkg-config
-        echo "Attempting to locate libopkg:"
-        pkg-config --cflags libopkg || echo "libopkg not found"
-        pkg-config --modversion libopkg
-        pkg-config --cflags libopkg
-        pkg-config --libs libopkg
-
-    - name: Ls all possible paths
-      run: |
-        echo "ls -la /usr/local/include:"
-        ls -la /usr/local/include
-        echo "ls -la /usr/local/lib:"
-        ls -la /usr/local/lib
-
-    - name: Copy the OPKG headers
+    - name: Copy libopkg headers
       run: |
         sudo mkdir -p /usr/local/include/libopkg
-        sudo cp /home/runner/work/ThunderNanoServicesRDK/ThunderNanoServicesRDK/opkg/libopkg/*.h /usr/local/include/libopkg
-        echo "ls -la /usr/local/include/libopkg:"
-        ls -la /usr/local/include/libopkg
+        sudo cp $GITHUB_WORKSPACE/opkg/libopkg/*.h /usr/local/include/libopkg
 
     - name: Build ThunderNanoServicesRDK
       run: |

--- a/.github/workflows/Linux build template.yml
+++ b/.github/workflows/Linux build template.yml
@@ -71,7 +71,7 @@ jobs:
       run: |
         cd opkg
         ./autogen.sh || true
-        ./configure
+        ./configure --prefix=/usr/local --includedir=/usr/local/include/libopkg
         make
         sudo make install
 

--- a/.github/workflows/Linux build template.yml
+++ b/.github/workflows/Linux build template.yml
@@ -69,6 +69,7 @@ jobs:
 # ----- Build & upload artifacts -----
     - name: Build libopkg
       run: |
+        ${{matrix.architecture == '32' && 'export PKG_CONFIG_PATH=/usr/lib/i386-linux-gnu/pkgconfig:$PKG_CONFIG_PATH' || 'PKG_CONFIG_PATH=/usr/lib/x86_64-linux-gnu/pkgconfig:$PKG_CONFIG_PATH'}}
         cd opkg
         ./autogen.sh || true
         ./configure --prefix=/usr/local ${{matrix.architecture == '32' && 'CFLAGS="-m32" LDFLAGS="-m32"' || ''}}

--- a/.github/workflows/Linux build template.yml
+++ b/.github/workflows/Linux build template.yml
@@ -93,6 +93,13 @@ jobs:
         echo "ls -la /usr/local/lib:"
         ls -la /usr/local/lib
 
+    - name: Copy the OPKG headers
+      run: |
+        sudo mkdir -p /usr/local/include/libopkg
+        sudo cp /home/runner/work/ThunderNanoServicesRDK/ThunderNanoServicesRDK/opkg/libopkg/*.h /usr/local/include/libopkg
+        echo "ls -la /usr/local/include/libopkg:"
+        ls -la /usr/local/include/libopkg
+
     - name: Build ThunderNanoServicesRDK
       run: |
         source venv/bin/activate

--- a/.github/workflows/Linux build template.yml
+++ b/.github/workflows/Linux build template.yml
@@ -85,8 +85,15 @@ jobs:
         pkg-config --modversion libopkg
         pkg-config --cflags libopkg
         pkg-config --libs libopkg
-        echo "ls -la /usr/local/include/opkg*:"
-        ls -la /usr/local/include/opkg*
+
+    - name: Ls all possible paths
+      run: |
+        echo "ls -la /usr/local/include:"
+        ls -la /usr/local/include
+        echo "ls -la /usr/local/lib:"
+        ls -la /usr/local/lib
+        echo "ls -la /usr/local/include/libopkg:"
+        ls -la /usr/local/include/libopkg
     
     - name: Verify libopkg include directory
       run: |

--- a/.github/workflows/Linux build template.yml
+++ b/.github/workflows/Linux build template.yml
@@ -85,6 +85,8 @@ jobs:
         pkg-config --modversion libopkg
         pkg-config --cflags libopkg
         pkg-config --libs libopkg
+        echo "ls -la /usr/local/include/opkg*:"
+        ls -la /usr/local/include/opkg*
     
     - name: Verify libopkg include directory
       run: |

--- a/.github/workflows/Linux build template.yml
+++ b/.github/workflows/Linux build template.yml
@@ -86,6 +86,7 @@ jobs:
     - name: Build ThunderNanoServicesRDK
       run: |
         source venv/bin/activate
+        export PKG_CONFIG_PATH=/usr/local/include/libopkg:$PKG_CONFIG_PATH
         cmake -G Ninja -S ThunderNanoServicesRDK -B ${{matrix.build_type}}/build/ThunderNanoServicesRDK \
         -DCMAKE_CXX_FLAGS="-Wall -Wextra -Wpedantic -Werror -m${{matrix.architecture}}" \
         -DCMAKE_C_FLAGS="-Wall -Wextra -Wpedantic -Werror -m${{matrix.architecture}}" \

--- a/.github/workflows/Linux build template.yml
+++ b/.github/workflows/Linux build template.yml
@@ -69,7 +69,7 @@ jobs:
 # ----- Build & upload artifacts -----
     - name: Build libopkg
       run: |
-        ${{matrix.architecture == '32' && 'export PKG_CONFIG_PATH=/usr/lib/i386-linux-gnu/pkgconfig:$PKG_CONFIG_PATH' || 'PKG_CONFIG_PATH=/usr/lib/x86_64-linux-gnu/pkgconfig:$PKG_CONFIG_PATH'}}
+        export PKG_CONFIG_PATH=/usr/lib/${{matrix.architecture == '32' && 'i386' || 'x86_64'}}-linux-gnu/pkgconfig:$PKG_CONFIG_PATH
         cd opkg
         ./autogen.sh || true
         ./configure --prefix=/usr/local ${{matrix.architecture == '32' && 'CFLAGS="-m32" LDFLAGS="-m32"' || ''}}

--- a/.github/workflows/Linux build template.yml
+++ b/.github/workflows/Linux build template.yml
@@ -86,7 +86,7 @@ jobs:
     - name: Build ThunderNanoServicesRDK
       run: |
         source venv/bin/activate
-        export PKG_CONFIG_PATH=/usr/local/include/libopkg/lib/pkgconfig:$PKG_CONFIG_PATH
+        export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig:$PKG_CONFIG_PATH
         cmake -G Ninja -S ThunderNanoServicesRDK -B ${{matrix.build_type}}/build/ThunderNanoServicesRDK \
         -DCMAKE_CXX_FLAGS="-Wall -Wextra -Wpedantic -Werror -m${{matrix.architecture}}" \
         -DCMAKE_C_FLAGS="-Wall -Wextra -Wpedantic -Werror -m${{matrix.architecture}}" \

--- a/.github/workflows/Linux build template.yml
+++ b/.github/workflows/Linux build template.yml
@@ -71,7 +71,7 @@ jobs:
       run: |
         cd opkg
         ./autogen.sh || true
-        ./configure --prefix=/usr/local
+        ./configure
         make
         sudo make install
 
@@ -86,7 +86,6 @@ jobs:
     - name: Build ThunderNanoServicesRDK
       run: |
         source venv/bin/activate
-        export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig:$PKG_CONFIG_PATH
         cmake -G Ninja -S ThunderNanoServicesRDK -B ${{matrix.build_type}}/build/ThunderNanoServicesRDK \
         -DCMAKE_CXX_FLAGS="-Wall -Wextra -Wpedantic -Werror -m${{matrix.architecture}}" \
         -DCMAKE_C_FLAGS="-Wall -Wextra -Wpedantic -Werror -m${{matrix.architecture}}" \

--- a/.github/workflows/Linux build template.yml
+++ b/.github/workflows/Linux build template.yml
@@ -71,7 +71,7 @@ jobs:
       run: |
         cd opkg
         ./autogen.sh || true
-        ./configure --prefix=/usr/local/include/libopkg
+        ./configure --prefix=/usr/local
         make
         sudo make install
 

--- a/.github/workflows/Linux build template.yml
+++ b/.github/workflows/Linux build template.yml
@@ -28,7 +28,7 @@ jobs:
           echo "deb http://archive.ubuntu.com/ubuntu/ jammy-updates main universe restricted multiverse" | sudo tee -a /etc/apt/sources.list
           sudo dpkg --add-architecture i386
           sudo apt-get update
-          sudo apt install python3-pip build-essential cmake ninja-build libusb-1.0-0-dev ${{matrix.architecture == '32' && 'zlib1g-dev:i386 libssl-dev:i386 gcc-13-multilib g++-13-multilib' || 'zlib1g-dev libssl-dev'}}
+          sudo apt install python3-pip build-essential cmake ninja-build libusb-1.0-0-dev autoconf automake libtool libtool-bin pkg-config libarchive-dev libcurl4-openssl-dev libgpgme-dev ${{matrix.architecture == '32' && 'zlib1g-dev:i386 libssl-dev:i386 gcc-13-multilib g++-13-multilib' || 'zlib1g-dev libssl-dev'}}
           python3 -m venv venv
           source venv/bin/activate
           pip install jsonref
@@ -60,7 +60,21 @@ jobs:
         regex_flags: 'gim'
         search_string: ${{github.event.pull_request.body}}
 
+    - name: Checkout OPKG
+      uses: actions/checkout@v4
+      with:
+        path: opkg
+        repository: oe-mirrors/opkg
+
 # ----- Build & upload artifacts -----
+    - name: Build libopkg
+      run: |
+        cd opkg
+        ./autogen.sh || true
+        ./configure --prefix=/usr/local/include/libopkg
+        make
+        sudo make install
+
     - name: Build ThunderNanoServicesRDK
       run: |
         source venv/bin/activate
@@ -77,6 +91,7 @@ jobs:
         -DPLUGIN_MONITOR=ON \
         -DPLUGIN_OPENCDMI=ON \
         -DPLUGIN_PERFORMANCEMETRICS=ON \
+        -DPLUGIN_PACKAGER=ON \
         ${{steps.plugins.outputs.first_match}}
         cmake --build ${{matrix.build_type}}/build/ThunderNanoServicesRDK --target install
 

--- a/.github/workflows/Linux build template.yml
+++ b/.github/workflows/Linux build template.yml
@@ -7,9 +7,6 @@ jobs:
   ThunderNanoServicesRDK:
 
     runs-on: ubuntu-24.04
-    
-    env:
-      PKG_CONFIG_PATH: "/usr/local/include/libopkg:$PKG_CONFIG_PATH"
 
     strategy:
       matrix:
@@ -89,7 +86,7 @@ jobs:
     - name: Build ThunderNanoServicesRDK
       run: |
         source venv/bin/activate
-        export PKG_CONFIG_PATH=/usr/local/include/libopkg:$PKG_CONFIG_PATH
+        export PKG_CONFIG_PATH=/usr/local/include/libopkg/lib/pkgconfig:$PKG_CONFIG_PATH
         cmake -G Ninja -S ThunderNanoServicesRDK -B ${{matrix.build_type}}/build/ThunderNanoServicesRDK \
         -DCMAKE_CXX_FLAGS="-Wall -Wextra -Wpedantic -Werror -m${{matrix.architecture}}" \
         -DCMAKE_C_FLAGS="-Wall -Wextra -Wpedantic -Werror -m${{matrix.architecture}}" \

--- a/.github/workflows/Linux build template.yml
+++ b/.github/workflows/Linux build template.yml
@@ -71,11 +71,11 @@ jobs:
       run: |
         cd opkg
         ./autogen.sh || true
-        ./configure --prefix=/usr/local
+        ./configure --prefix=/usr/local ${{matrix.architecture == '32' && 'CFLAGS="-m32" LDFLAGS="-m32"' || ''}}
         make
         sudo make install
 
-    - name: Copy libopkg headers
+    - name: Install libopkg headers
       run: |
         sudo mkdir -p /usr/local/include/libopkg
         sudo cp $GITHUB_WORKSPACE/opkg/libopkg/*.h /usr/local/include/libopkg


### PR DESCRIPTION
Building Packager requires us to also manually build `libopkg` (which was quite challenging to get right on the runner), as it is not available as a package to be installed, but nonetheless it takes relatively short amount of time, and now we won't have a situation of _someone_ breaking Packager without realizing it 😄 