### PR TITLE
[PlayerInfo][Actions] Fixing a compile error, installing a package suddenly missing on the runner

### DIFF
--- a/.github/workflows/Build ThunderNanoServicesRDK on Linux.yml
+++ b/.github/workflows/Build ThunderNanoServicesRDK on Linux.yml
@@ -17,4 +17,4 @@ jobs:
 
   ThunderNanoServicesRDK:
     needs: ThunderInterfaces
-    uses: WebPlatformForEmbedded/ThunderNanoServicesRDK/.github/workflows/Linux build template.yml@development/actions-directory-missing
+    uses: WebPlatformForEmbedded/ThunderNanoServicesRDK/.github/workflows/Linux build template.yml@master

--- a/.github/workflows/Build ThunderNanoServicesRDK on Linux.yml
+++ b/.github/workflows/Build ThunderNanoServicesRDK on Linux.yml
@@ -17,4 +17,4 @@ jobs:
 
   ThunderNanoServicesRDK:
     needs: ThunderInterfaces
-    uses: WebPlatformForEmbedded/ThunderNanoServicesRDK/.github/workflows/Linux build template.yml@master
+    uses: WebPlatformForEmbedded/ThunderNanoServicesRDK/.github/workflows/Linux build template.yml@development/actions-directory-missing

--- a/.github/workflows/Linux build template.yml
+++ b/.github/workflows/Linux build template.yml
@@ -60,26 +60,26 @@ jobs:
         regex_flags: 'gim'
         search_string: ${{github.event.pull_request.body}}
 
-    - name: Checkout libopkg
-      uses: actions/checkout@v4
-      with:
-        path: opkg
-        repository: oe-mirrors/opkg
+#    - name: Checkout libopkg
+#      uses: actions/checkout@v4
+#      with:
+#        path: opkg
+#        repository: oe-mirrors/opkg
 
 # ----- Build & upload artifacts -----
-    - name: Build libopkg
-      run: |
-        export PKG_CONFIG_PATH=/usr/lib/${{matrix.architecture == '32' && 'i386' || 'x86_64'}}-linux-gnu/pkgconfig:$PKG_CONFIG_PATH
-        cd opkg
-        ./autogen.sh || true
-        ./configure --prefix=/usr/local ${{matrix.architecture == '32' && 'CFLAGS="-m32" LDFLAGS="-m32"' || ''}}
-        make
-        sudo make install
+#    - name: Build libopkg
+#      run: |
+#        export PKG_CONFIG_PATH=/usr/lib/${{matrix.architecture == '32' && 'i386' || 'x86_64'}}-linux-gnu/pkgconfig:$PKG_CONFIG_PATH
+#        cd opkg
+#        ./autogen.sh || true
+#        ./configure --prefix=/usr/local ${{matrix.architecture == '32' && 'CFLAGS="-m32" LDFLAGS="-m32"' || ''}}
+#        make
+#        sudo make install
 
-    - name: Install libopkg headers
-      run: |
-        sudo mkdir -p /usr/local/include/libopkg
-        sudo cp $GITHUB_WORKSPACE/opkg/libopkg/*.h /usr/local/include/libopkg
+#    - name: Install libopkg headers
+#      run: |
+#        sudo mkdir -p /usr/local/include/libopkg
+#        sudo cp $GITHUB_WORKSPACE/opkg/libopkg/*.h /usr/local/include/libopkg
 
     - name: Build ThunderNanoServicesRDK
       run: |
@@ -99,7 +99,7 @@ jobs:
         -DPLUGIN_OPENCDMI=ON \
         -DPLUGIN_PERFORMANCEMETRICS=ON \
         -DPLUGIN_PLAYERINFO=ON \
-        -DPLUGIN_PACKAGER=ON \
+        -DPLUGIN_PACKAGER=OFF \
         ${{steps.plugins.outputs.first_match}}
         cmake --build ${{matrix.build_type}}/build/ThunderNanoServicesRDK --target install
 

--- a/.github/workflows/Linux build template.yml
+++ b/.github/workflows/Linux build template.yml
@@ -84,7 +84,7 @@ jobs:
     - name: Build ThunderNanoServicesRDK
       run: |
         source venv/bin/activate
-        export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig:/usr/lib/${{matrix.architecture == '32' && 'i386' || 'x86_64'}}-linux-gnu/pkgconfig:$PKG_CONFIG_PATH
+        export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig:$PKG_CONFIG_PATH
         cmake -G Ninja -S ThunderNanoServicesRDK -B ${{matrix.build_type}}/build/ThunderNanoServicesRDK \
         -DCMAKE_CXX_FLAGS="-Wall -Wextra -Wpedantic -Werror -m${{matrix.architecture}}" \
         -DCMAKE_C_FLAGS="-Wall -Wextra -Wpedantic -Werror -m${{matrix.architecture}}" \

--- a/.github/workflows/Linux build template.yml
+++ b/.github/workflows/Linux build template.yml
@@ -28,7 +28,7 @@ jobs:
           echo "deb http://archive.ubuntu.com/ubuntu/ jammy-updates main universe restricted multiverse" | sudo tee -a /etc/apt/sources.list
           sudo dpkg --add-architecture i386
           sudo apt-get update
-          sudo apt install python3-pip build-essential cmake ninja-build libusb-1.0-0-dev autoconf automake libtool libtool-bin pkg-config ${{matrix.architecture == '32' && 'zlib1g-dev:i386 libssl-dev:i386 gcc-13-multilib g++-13-multilib libarchive-dev:i386 libcurl4-openssl-dev:i386 libgpgme-dev:i386 libgpg-error-dev:i386 libgstreamer1.0-dev:i386' || 'zlib1g-dev libssl-dev libarchive-dev libcurl4-openssl-dev libgpgme-dev libgpg-error-dev libgstreamer1.0-dev'}}
+          sudo apt install python3-pip python3-venv build-essential cmake ninja-build libusb-1.0-0-dev autoconf automake libtool libtool-bin pkg-config ${{matrix.architecture == '32' && 'zlib1g-dev:i386 libssl-dev:i386 gcc-13-multilib g++-13-multilib libarchive-dev:i386 libcurl4-openssl-dev:i386 libgpgme-dev:i386 libgpg-error-dev:i386 libgstreamer1.0-dev:i386' || 'zlib1g-dev libssl-dev libarchive-dev libcurl4-openssl-dev libgpgme-dev libgpg-error-dev libgstreamer1.0-dev'}}
           python3 -m venv venv
           source venv/bin/activate
           pip install jsonref
@@ -60,31 +60,31 @@ jobs:
         regex_flags: 'gim'
         search_string: ${{github.event.pull_request.body}}
 
-#    - name: Checkout libopkg
-#      uses: actions/checkout@v4
-#      with:
-#        path: opkg
-#        repository: oe-mirrors/opkg
+    - name: Checkout libopkg
+      uses: actions/checkout@v4
+      with:
+        path: opkg
+        repository: oe-mirrors/opkg
 
 # ----- Build & upload artifacts -----
-#    - name: Build libopkg
-#      run: |
-#        export PKG_CONFIG_PATH=/usr/lib/${{matrix.architecture == '32' && 'i386' || 'x86_64'}}-linux-gnu/pkgconfig:$PKG_CONFIG_PATH
-#        cd opkg
-#        ./autogen.sh || true
-#        ./configure --prefix=/usr/local ${{matrix.architecture == '32' && 'CFLAGS="-m32" LDFLAGS="-m32"' || ''}}
-#        make
-#        sudo make install
+    - name: Build libopkg
+      run: |
+        export PKG_CONFIG_PATH=/usr/lib/${{matrix.architecture == '32' && 'i386' || 'x86_64'}}-linux-gnu/pkgconfig:$PKG_CONFIG_PATH
+        cd opkg
+        ./autogen.sh || true
+        ./configure --prefix=/usr/local ${{matrix.architecture == '32' && 'CFLAGS="-m32" LDFLAGS="-m32"' || ''}}
+        make
+        sudo make install
 
-#    - name: Install libopkg headers
-#      run: |
-#        sudo mkdir -p /usr/local/include/libopkg
-#        sudo cp $GITHUB_WORKSPACE/opkg/libopkg/*.h /usr/local/include/libopkg
+    - name: Install libopkg headers
+      run: |
+        sudo mkdir -p /usr/local/include/libopkg
+        sudo cp $GITHUB_WORKSPACE/opkg/libopkg/*.h /usr/local/include/libopkg
 
     - name: Build ThunderNanoServicesRDK
       run: |
         source venv/bin/activate
-        export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig:$PKG_CONFIG_PATH
+        export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig:/usr/lib/${{matrix.architecture == '32' && 'i386' || 'x86_64'}}-linux-gnu/pkgconfig:$PKG_CONFIG_PATH
         cmake -G Ninja -S ThunderNanoServicesRDK -B ${{matrix.build_type}}/build/ThunderNanoServicesRDK \
         -DCMAKE_CXX_FLAGS="-Wall -Wextra -Wpedantic -Werror -m${{matrix.architecture}}" \
         -DCMAKE_C_FLAGS="-Wall -Wextra -Wpedantic -Werror -m${{matrix.architecture}}" \
@@ -99,7 +99,7 @@ jobs:
         -DPLUGIN_OPENCDMI=ON \
         -DPLUGIN_PERFORMANCEMETRICS=ON \
         -DPLUGIN_PLAYERINFO=ON \
-        -DPLUGIN_PACKAGER=OFF \
+        -DPLUGIN_PACKAGER=ON \
         ${{steps.plugins.outputs.first_match}}
         cmake --build ${{matrix.build_type}}/build/ThunderNanoServicesRDK --target install
 

--- a/PlayerInfo/GStreamer/PlatformImplementation.cpp
+++ b/PlayerInfo/GStreamer/PlatformImplementation.cpp
@@ -58,10 +58,10 @@ private:
             for (auto index: caps) {
 
                 MediaTypes mediaType{gst_caps_from_string(index.first.c_str())};
-                if (elements = std::move(GstUtils::GstRegistryGetElementForMediaType(decoderFactories.get(), std::move(mediaType)))) {
+                if ((elements = std::move(GstUtils::GstRegistryGetElementForMediaType(decoderFactories.get(), std::move(mediaType))))) {
                     codecIteratorList.push_back(index.second);
 
-                } else if (elements = std::move(GstUtils::GstRegistryGetElementForMediaType(parserFactories.get(), std::move(mediaType)))) {
+                } else if ((elements = std::move(GstUtils::GstRegistryGetElementForMediaType(parserFactories.get(), std::move(mediaType))))) {
 
                     for (GList* iterator = elements.get(); iterator; iterator = iterator->next) {
 


### PR DESCRIPTION
This was the compile error from PlayerInfo:
```
/home/runner/work/ThunderNanoServicesRDK/ThunderNanoServicesRDK/ThunderNanoServicesRDK/PlayerInfo/GStreamer/PlatformImplementation.cpp:61:17: error: suggest parentheses around assignment used as truth value [-Werror=parentheses]
   61 |                 if (elements = std::move(GstUtils::GstRegistryGetElementForMediaType(decoderFactories.get(), std::move(mediaType)))) {
      |                 ^~
/home/runner/work/ThunderNanoServicesRDK/ThunderNanoServicesRDK/ThunderNanoServicesRDK/PlayerInfo/GStreamer/PlatformImplementation.cpp:64:24: error: suggest parentheses around assignment used as truth value [-Werror=parentheses]
   64 |                 } else if (elements = std::move(GstUtils::GstRegistryGetElementForMediaType(parserFactories.get(), std::move(mediaType)))) {
      |                        ^~
/home/runner/work/ThunderNanoServicesRDK/ThunderNanoServicesRDK/ThunderNanoServicesRDK/PlayerInfo/GStreamer/PlatformImplementation.cpp: In instantiation of ‘static bool Thunder::Plugin::PlayerInfoImplementation::GstUtils::GstRegistryCheckElementsForMediaTypes(C, CodecIteratorList&) [with C = std::map<const std::__cxx11::basic_string<char>, const Thunder::Exchange::IPlayerProperties::VideoCodec>; CodecIteratorList = std::__cxx11::list<Thunder::Exchange::IPlayerProperties::VideoCodec>]’:
/home/runner/work/ThunderNanoServicesRDK/ThunderNanoServicesRDK/ThunderNanoServicesRDK/PlayerInfo/GStreamer/PlatformImplementation.cpp:188:60:   required from here
/home/runner/work/ThunderNanoServicesRDK/ThunderNanoServicesRDK/ThunderNanoServicesRDK/PlayerInfo/GStreamer/PlatformImplementation.cpp:61:17: error: suggest parentheses around assignment used as truth value [-Werror=parentheses]
   61 |                 if (elements = std::move(GstUtils::GstRegistryGetElementForMediaType(decoderFactories.get(), std::move(mediaType)))) {
      |                 ^~
/home/runner/work/ThunderNanoServicesRDK/ThunderNanoServicesRDK/ThunderNanoServicesRDK/PlayerInfo/GStreamer/PlatformImplementation.cpp:64:24: error: suggest parentheses around assignment used as truth value [-Werror=parentheses]
   64 |                 } else if (elements = std::move(GstUtils::GstRegistryGetElementForMediaType(parserFactories.get(), std::move(mediaType)))) {
      |                        ^~
```

On top of that, it looks like one package that was available on all Linux runners from the start is now missing.. and what's even more strange, this error seems to take place only in this repository, so let's for now explicitly download that package just here..