### PR TITLE
Marking plugin as inactive during deactivate.

### DIFF
--- a/Monitor/Monitor.h
+++ b/Monitor/Monitor.h
@@ -768,6 +768,13 @@ POP_WARNING()
             }
             void Deactivated (const string&, PluginHost::IShell*) override
             {
+                MonitorObjectContainer::iterator index(_monitor.find(callsign));
+
+                if (index != _monitor.end()) {
+
+                    index->second.Set(nullptr);
+                    index->second.Active(false);
+                }
             }
             void Unavailable(const string&, PluginHost::IShell*) override
             {


### PR DESCRIPTION
This will make monitor to not pick a plugin for which the deactivate is in progress