### PR TITLE
[MessageControl] Fix a shutdown issue

### DIFF
--- a/MessageControl/MessageControl.cpp
+++ b/MessageControl/MessageControl.cpp
@@ -68,6 +68,7 @@ namespace Thunder {
         , _outputDirector()
         , _webSocketExporter()
         , _callback(nullptr)
+        , _cleaning()
         , _observer(*this)
         , _service(nullptr)
         , _dispatcherIdentifier(Messaging::MessageUnit::Instance().Identifier())

--- a/MessageControl/MessageControl.h
+++ b/MessageControl/MessageControl.h
@@ -464,6 +464,7 @@ namespace Plugin {
         OutputList _outputDirector;
         Publishers::WebSocketOutput _webSocketExporter;
         MessageControl::ICollect::ICallback* _callback;
+        Cleanups _cleaning;
         Core::SinkType<Observer> _observer;
         PluginHost::IShell* _service;
         const string _dispatcherIdentifier;
@@ -475,7 +476,6 @@ namespace Plugin {
         Messaging::TraceFactoryType<Core::Messaging::IStore::WarningReporting, Core::Messaging::TextMessage> _warningReportingFactory;
         Messaging::TraceFactoryType<Core::Messaging::IStore::OperationalStream, Core::Messaging::TextMessage> _operationalStreamFactory;
         Messaging::TraceFactoryType<Core::Messaging::IStore::Assert, Core::Messaging::TextMessage> _assertFactory;
-        Cleanups _cleaning;
     };
 
 } // namespace Plugin


### PR DESCRIPTION
The Cleanups vector has to outlive the Observer member of MessageControl during its destruction, otherwise if someone tries to Detach in the meantime, the iterator in the Cleanup() method will become invalid